### PR TITLE
Substitute empty internalFieldName in API response

### DIFF
--- a/api/src/main/java/datawave/webservice/results/datadictionary/DataDictionaryBase.java
+++ b/api/src/main/java/datawave/webservice/results/datadictionary/DataDictionaryBase.java
@@ -11,6 +11,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlSeeAlso(DefaultDataDictionary.class)
@@ -31,4 +32,6 @@ public abstract class DataDictionaryBase<T,M extends MetadataFieldBase> extends 
     public abstract String getPageHeader();
     
     public abstract String getMainContent();
+    
+    public abstract void transformFields(final Consumer<M> transformer);
 }

--- a/api/src/main/java/datawave/webservice/results/datadictionary/DefaultDataDictionary.java
+++ b/api/src/main/java/datawave/webservice/results/datadictionary/DefaultDataDictionary.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 import javax.xml.bind.annotation.XmlAccessOrder;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -257,6 +258,11 @@ public class DefaultDataDictionary extends DataDictionaryBase<DefaultDataDiction
         builder.append("</table>\n");
         
         return builder.toString();
+    }
+    
+    @Override
+    public void transformFields(Consumer<DefaultMetadataField> transformer) {
+        fields.forEach(transformer);
     }
     
     @Override

--- a/service/src/main/java/datawave/microservice/dictionary/DataDictionaryOperations.java
+++ b/service/src/main/java/datawave/microservice/dictionary/DataDictionaryOperations.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static datawave.microservice.http.converter.protostuff.ProtostuffHttpMessageConverter.PROTOSTUFF_VALUE;
@@ -58,6 +59,12 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
     private final ResponseObjectFactory<DESC,DICT,META,FIELD,FIELDS> responseObjectFactory;
     private final UserAuthFunctions userAuthFunctions;
     private final Connector accumuloConnector;
+    
+    private final Consumer<META> TRANSFORM_EMPTY_INTERNAL_FIELD_NAMES = meta -> {
+        if (meta.getInternalFieldName() == null || meta.getInternalFieldName().isEmpty()) {
+            meta.setInternalFieldName(meta.getFieldName());
+        }
+    };
     
     public DataDictionaryOperations(DataDictionaryProperties dataDictionaryConfiguration, DatawaveDataDictionary<META,DESC,FIELD> dataDictionary,
                     ResponseObjectFactory<DESC,DICT,META,FIELD,FIELDS> responseObjectFactory, UserAuthFunctions userAuthFunctions,
@@ -96,8 +103,9 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
                         dataDictionaryConfiguration.getNumThreads());
         DICT dataDictionary = responseObjectFactory.getDataDictionary();
         dataDictionary.setFields(fields);
+        // Ensure that empty internal field names will be set to the field name instead.
+        dataDictionary.transformFields(TRANSFORM_EMPTY_INTERNAL_FIELD_NAMES);
         return dataDictionary;
-        
     }
     
     /**


### PR DESCRIPTION
When returning DataDictionary results via the REST API, if the internal
field name is empty, substitute the value of the field name instead.

Fixes [#709](https://github.com/NationalSecurityAgency/datawave/issues/709)

This is meant to edit responses from the API only, and refrain from modifying any internal instances of a `MetadataFieldBase` that may be used in internal operations.
