### PR TITLE
Correctly determine lastUpdated of index-only fields

### DIFF
--- a/service/src/main/java/datawave/microservice/dictionary/data/DatawaveDataDictionaryImpl.java
+++ b/service/src/main/java/datawave/microservice/dictionary/data/DatawaveDataDictionaryImpl.java
@@ -199,13 +199,17 @@ public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<Defaul
                         // Handle index-only fields, which have no "e" entry
                         if (field.getFieldName() == null) {
                             String fieldName = key.getRow().toString();
-                            field.setLastUpdated(parseTimestamp(key.getTimestamp()));
                             if (reverseMapping.containsKey(fieldName)) {
                                 field.setFieldName(reverseMapping.get(fieldName));
                                 field.setInternalFieldName(fieldName);
                             } else {
                                 field.setFieldName(fieldName);
                             }
+                        }
+                        
+                        // Determine the lastUpdated value for index-only fields without including timestamps from description rows.
+                        if (field.isIndexOnly() && field.getLastUpdated() == null && !ColumnFamilyConstants.COLF_DESC.equals(holder)) {
+                            field.setLastUpdated(parseTimestamp(key.getTimestamp()));
                         }
                     }
                     


### PR DESCRIPTION
When a description row is the first entry returned for a particular
field that is index-only, lastUpdated will be (incorrectly) set to when
the description row was created.

Disregard description rows when establishing lastUpdated for index-only
fields, and instead use the timestamp of the first non-description row
returned.

Fixes #476