### PR TITLE
Support pagination when searching dictionary fields

### DIFF
--- a/service/src/main/java/datawave/microservice/dictionary/DataDictionaryOperations.java
+++ b/service/src/main/java/datawave/microservice/dictionary/DataDictionaryOperations.java
@@ -75,7 +75,9 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
     @Timed(name = "dw.dictionary.data.get", absolute = true)
     public DataDictionaryBase<DICT,META> get(@RequestParam(required = false) String modelName, @RequestParam(required = false) String modelTableName,
                     @RequestParam(required = false) String metadataTableName, @RequestParam(name = "auths", required = false) String queryAuthorizations,
-                    @RequestParam(defaultValue = "") String dataTypeFilters, @AuthenticationPrincipal ProxiedUserDetails currentUser) throws Exception {
+                    @RequestParam(defaultValue = "") String dataTypeFilters, @RequestParam(name = "limit", required = false, defaultValue = "-1") int limit,
+                    @RequestParam(name = "offset", required = false, defaultValue = "0") int offset, @AuthenticationPrincipal ProxiedUserDetails currentUser)
+                    throws Exception {
         if (null == modelName || StringUtils.isBlank(modelName)) {
             modelName = this.dataDictionaryConfiguration.getModelName();
         }
@@ -93,7 +95,8 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
         // If the user provides authorizations, intersect it with their actual authorizations
         Set<Authorizations> auths = getDowngradedAuthorizations(queryAuthorizations, currentUser);
         Collection<META> fields = dataDictionary.getFields(modelName, modelTableName, metadataTableName, dataTypes, accumuloConnector, auths,
-                        dataDictionaryConfiguration.getNumThreads());
+                        dataDictionaryConfiguration.getNumThreads(), limit, offset);
+        
         DICT dataDictionary = responseObjectFactory.getDataDictionary();
         dataDictionary.setFields(fields);
         return dataDictionary;

--- a/service/src/main/java/datawave/microservice/dictionary/data/DatawaveDataDictionary.java
+++ b/service/src/main/java/datawave/microservice/dictionary/data/DatawaveDataDictionary.java
@@ -14,7 +14,7 @@ import java.util.Set;
 
 public interface DatawaveDataDictionary<META extends MetadataFieldBase<META,DESC>,DESC extends DescriptionBase<DESC>,FIELD extends DictionaryFieldBase<FIELD,DESC>> {
     Collection<META> getFields(String modelName, String modelTableName, String metadataTableName, Collection<String> dataTypeFilters, Connector connector,
-                    Set<Authorizations> auths, int numThreads) throws Exception;
+                    Set<Authorizations> auths, int numThreads, int limit, int offset) throws Exception;
     
     Map<String,String> getNormalizerMapping();
     


### PR DESCRIPTION
The REST endpoint for retrieving data dictionary fields can return
fairly large responses, causing issues in browsers.

Add the ability to paginate the fields returned when searching with the
following new parameters:

- limit: the total fields to return
- offset: the total fields to skip before applying the limit

Fixes #706