### PR TITLE
Do initial refactor of data dictionary service

### DIFF
--- a/api/src/main/java/datawave/webservice/query/result/metadata/DefaultMetadataField.java
+++ b/api/src/main/java/datawave/webservice/query/result/metadata/DefaultMetadataField.java
@@ -1,5 +1,22 @@
 package datawave.webservice.query.result.metadata;
 
+import datawave.webservice.query.result.event.MapSchema;
+import datawave.webservice.results.datadictionary.DefaultDescription;
+import datawave.webservice.results.datadictionary.DescriptionBase;
+import io.protostuff.Input;
+import io.protostuff.Message;
+import io.protostuff.Output;
+import io.protostuff.Schema;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -9,25 +26,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
-
-import datawave.webservice.query.result.event.MapSchema;
-import datawave.webservice.results.datadictionary.DefaultDescription;
-
-import datawave.webservice.results.datadictionary.DescriptionBase;
-
-import io.protostuff.Input;
-import io.protostuff.Message;
-import io.protostuff.Output;
-import io.protostuff.Schema;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlType(propOrder = {"fieldName", "internalFieldName", "dataType", "descriptions", "indexOnly", "forwardIndexed", "reverseIndexed", "normalized", "tokenized",
@@ -168,6 +166,24 @@ public class DefaultMetadataField extends MetadataFieldBase<DefaultMetadataField
     @Override
     public int hashCode() {
         return new HashCodeBuilder(6197, 7993).append(this.fieldName).hashCode();
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        
+        DefaultMetadataField field = (DefaultMetadataField) o;
+        
+        return new EqualsBuilder().append(fieldName, field.fieldName).append(internalFieldName, field.internalFieldName).append(dataType, field.dataType)
+                        .append(indexOnly, field.indexOnly).append(forwardIndexed, field.forwardIndexed).append(normalized, field.normalized)
+                        .append(reverseIndexed, field.reverseIndexed).append(tokenized, field.tokenized).append(types, field.types)
+                        .append(descriptions, field.descriptions).append(lastUpdated, field.lastUpdated).isEquals();
     }
     
     @SuppressWarnings("unused")

--- a/service/src/main/java/datawave/microservice/dictionary/DataDictionaryOperations.java
+++ b/service/src/main/java/datawave/microservice/dictionary/DataDictionaryOperations.java
@@ -164,15 +164,23 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
     /**
      * Set a description for a field in a datatype, optionally applying a model to the field name.
      *
-     * @param fieldName        Name of field
-     * @param datatype         Name of datatype
-     * @param description      Description of field
-     * @param modelName        Optional model name
-     * @param modelTable       Optional model table name
-     * @param columnVisibility ColumnVisibility of the description
-     * @param currentUser      The user sending the request
+     * @param fieldName
+     *            Name of field
+     * @param datatype
+     *            Name of datatype
+     * @param description
+     *            Description of field
+     * @param modelName
+     *            Optional model name
+     * @param modelTable
+     *            Optional model table name
+     * @param columnVisibility
+     *            ColumnVisibility of the description
+     * @param currentUser
+     *            The user sending the request
      * @return Description of fields
-     * @throws Exception if there is any problem updating the dictionary item description
+     * @throws Exception
+     *             if there is any problem updating the dictionary item description
      */
     @RolesAllowed({"Administrator", "JBossAdministrator"})
     @PostMapping(path = "/Descriptions", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE,
@@ -197,11 +205,15 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
     /**
      * Fetch all descriptions stored in the database, optionally applying a model.
      *
-     * @param modelName  Optional model name
-     * @param modelTable Optional model table name
-     * @param currentUser The user sending the request
+     * @param modelName
+     *            Optional model name
+     * @param modelTable
+     *            Optional model table name
+     * @param currentUser
+     *            The user sending the request
      * @return the dictionary descriptions
-     * @throws Exception if there is any problem retrieving the descriptions from Accumulo
+     * @throws Exception
+     *             if there is any problem retrieving the descriptions from Accumulo
      */
     @RequestMapping(path = "/Descriptions")
     @ResponseBody
@@ -218,12 +230,17 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
     /**
      * Fetch all descriptions for a datatype, optionally applying a model to the field names.
      *
-     * @param datatype   Name of datatype
-     * @param modelName  Optional model name
-     * @param modelTable Optional model table name
-     * @param currentUser The user sending the request
+     * @param datatype
+     *            Name of datatype
+     * @param modelName
+     *            Optional model name
+     * @param modelTable
+     *            Optional model table name
+     * @param currentUser
+     *            The user sending the request
      * @return the dictionary descriptions for {@code datatype}
-     * @throws Exception if there is any problem retrieving the descriptions from Accumulo
+     * @throws Exception
+     *             if there is any problem retrieving the descriptions from Accumulo
      */
     @RequestMapping(path = "/Descriptions/{datatype}")
     @Timed(name = "dw.dictionary.data.datatypeDescriptions", absolute = true)
@@ -239,13 +256,19 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
     /**
      * Fetch the description for a field in a datatype, optionally applying a model.
      *
-     * @param fieldName  Name of field
-     * @param datatype   Name of datatype
-     * @param modelName  Optional model name
-     * @param modelTable Optional model table name
-     * @param currentUser The user sending the request
+     * @param fieldName
+     *            Name of field
+     * @param datatype
+     *            Name of datatype
+     * @param modelName
+     *            Optional model name
+     * @param modelTable
+     *            Optional model table name
+     * @param currentUser
+     *            The user sending the request
      * @return the dictionary descriptions for field {@code fieldName} in the type {@code dataType}
-     * @throws Exception if there is any problem retrieving the descriptions from Accumulo
+     * @throws Exception
+     *             if there is any problem retrieving the descriptions from Accumulo
      */
     @RequestMapping(path = "/Descriptions/{datatype}/{fieldName}")
     @Timed(name = "dw.dictionary.data.fieldNameDescription", absolute = true)
@@ -267,14 +290,21 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
     /**
      * Delete a description for a field in a datatype, optionally applying a model to the field name.
      *
-     * @param fieldName  Name of field
-     * @param datatype   Name of datatype
-     * @param modelName  Optional model name
-     * @param modelTable Optional model table name
-     * @param columnVisibility the column visibility
-     * @param currentUser The user sending the request
+     * @param fieldName
+     *            Name of field
+     * @param datatype
+     *            Name of datatype
+     * @param modelName
+     *            Optional model name
+     * @param modelTable
+     *            Optional model table name
+     * @param columnVisibility
+     *            the column visibility
+     * @param currentUser
+     *            The user sending the request
      * @return a {@link VoidResponse} with operation time and error information
-     * @throws Exception if there is any problem removing the description from Accumulo
+     * @throws Exception
+     *             if there is any problem removing the description from Accumulo
      */
     @RolesAllowed({"Administrator", "JBossAdministrator"})
     @DeleteMapping(path = "/Descriptions/{datatype}/{fieldName}", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE,

--- a/service/src/main/java/datawave/microservice/dictionary/DataDictionaryOperations.java
+++ b/service/src/main/java/datawave/microservice/dictionary/DataDictionaryOperations.java
@@ -123,7 +123,7 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
         ConnectionConfig connectionConfig = getConnectionConfig(modelTable, modelName, currentUser);
         List<FIELD> list = fields.getFields();
         for (FIELD desc : list) {
-            dataDictionary.addDescription(connectionConfig, desc);
+            dataDictionary.setDescription(connectionConfig, desc);
         }
         // TODO: reload model table cache?
         // cache.reloadCache(modelTable);
@@ -196,7 +196,7 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
         desc.setDescription(description);
         
         ConnectionConfig connectionConfig = getConnectionConfig(modelTable, modelName, currentUser);
-        dataDictionary.addDescription(connectionConfig, fieldName, datatype, desc);
+        dataDictionary.setDescription(connectionConfig, fieldName, datatype, desc);
         // TODO: reload model table cache?
         // cache.reloadCache(modelTable);
         return new VoidResponse();

--- a/service/src/main/java/datawave/microservice/dictionary/DataDictionaryOperations.java
+++ b/service/src/main/java/datawave/microservice/dictionary/DataDictionaryOperations.java
@@ -109,6 +109,8 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
      *            Optional model name
      * @param modelTable
      *            Optional model table name
+     * @param currentUser
+     *            The user sending the request
      * @return a VoidResponse
      * @throws Exception
      *             if there is any problem uploading the descriptions
@@ -143,6 +145,8 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
      *            Optional model table name
      * @param columnVisibility
      *            ColumnVisibility of the description
+     * @param currentUser
+     *            The user sending the request
      * @return a {@link VoidResponse}
      * @throws Exception
      *             if there is any problem updating the description
@@ -160,21 +164,15 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
     /**
      * Set a description for a field in a datatype, optionally applying a model to the field name.
      *
-     * @param fieldName
-     *            Name of field
-     * @param datatype
-     *            Name of datatype
-     * @param description
-     *            Description of field
-     * @param modelName
-     *            Optional model name
-     * @param modelTable
-     *            Optional model table name
-     * @param columnVisibility
-     *            ColumnVisibility of the description
+     * @param fieldName        Name of field
+     * @param datatype         Name of datatype
+     * @param description      Description of field
+     * @param modelName        Optional model name
+     * @param modelTable       Optional model table name
+     * @param columnVisibility ColumnVisibility of the description
+     * @param currentUser      The user sending the request
      * @return Description of fields
-     * @throws Exception
-     *             if there is any problem updating the dictionary item description
+     * @throws Exception if there is any problem updating the dictionary item description
      */
     @RolesAllowed({"Administrator", "JBossAdministrator"})
     @PostMapping(path = "/Descriptions", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE,
@@ -199,13 +197,11 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
     /**
      * Fetch all descriptions stored in the database, optionally applying a model.
      *
-     * @param modelName
-     *            Optional model name
-     * @param modelTable
-     *            Optional model table name
+     * @param modelName  Optional model name
+     * @param modelTable Optional model table name
+     * @param currentUser The user sending the request
      * @return the dictionary descriptions
-     * @throws Exception
-     *             if there is any problem retrieving the descriptions from Accumulo
+     * @throws Exception if there is any problem retrieving the descriptions from Accumulo
      */
     @RequestMapping(path = "/Descriptions")
     @ResponseBody
@@ -222,15 +218,12 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
     /**
      * Fetch all descriptions for a datatype, optionally applying a model to the field names.
      *
-     * @param datatype
-     *            Name of datatype
-     * @param modelName
-     *            Optional model name
-     * @param modelTable
-     *            Optional model table name
+     * @param datatype   Name of datatype
+     * @param modelName  Optional model name
+     * @param modelTable Optional model table name
+     * @param currentUser The user sending the request
      * @return the dictionary descriptions for {@code datatype}
-     * @throws Exception
-     *             if there is any problem retrieving the descriptions from Accumulo
+     * @throws Exception if there is any problem retrieving the descriptions from Accumulo
      */
     @RequestMapping(path = "/Descriptions/{datatype}")
     @Timed(name = "dw.dictionary.data.datatypeDescriptions", absolute = true)
@@ -246,17 +239,13 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
     /**
      * Fetch the description for a field in a datatype, optionally applying a model.
      *
-     * @param fieldName
-     *            Name of field
-     * @param datatype
-     *            Name of datatype
-     * @param modelName
-     *            Optional model name
-     * @param modelTable
-     *            Optional model table name
+     * @param fieldName  Name of field
+     * @param datatype   Name of datatype
+     * @param modelName  Optional model name
+     * @param modelTable Optional model table name
+     * @param currentUser The user sending the request
      * @return the dictionary descriptions for field {@code fieldName} in the type {@code dataType}
-     * @throws Exception
-     *             if there is any problem retrieving the descriptions from Accumulo
+     * @throws Exception if there is any problem retrieving the descriptions from Accumulo
      */
     @RequestMapping(path = "/Descriptions/{datatype}/{fieldName}")
     @Timed(name = "dw.dictionary.data.fieldNameDescription", absolute = true)
@@ -278,17 +267,14 @@ public class DataDictionaryOperations<DESC extends DescriptionBase<DESC>,DICT ex
     /**
      * Delete a description for a field in a datatype, optionally applying a model to the field name.
      *
-     * @param fieldName
-     *            Name of field
-     * @param datatype
-     *            Name of datatype
-     * @param modelName
-     *            Optional model name
-     * @param modelTable
-     *            Optional model table name
+     * @param fieldName  Name of field
+     * @param datatype   Name of datatype
+     * @param modelName  Optional model name
+     * @param modelTable Optional model table name
+     * @param columnVisibility the column visibility
+     * @param currentUser The user sending the request
      * @return a {@link VoidResponse} with operation time and error information
-     * @throws Exception
-     *             if there is any problem removing the description from Accumulo
+     * @throws Exception if there is any problem removing the description from Accumulo
      */
     @RolesAllowed({"Administrator", "JBossAdministrator"})
     @DeleteMapping(path = "/Descriptions/{datatype}/{fieldName}", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE,

--- a/service/src/main/java/datawave/microservice/dictionary/data/ConnectionConfig.java
+++ b/service/src/main/java/datawave/microservice/dictionary/data/ConnectionConfig.java
@@ -1,0 +1,85 @@
+package datawave.microservice.dictionary.data;
+
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+import java.util.Objects;
+import java.util.Set;
+
+public class ConnectionConfig {
+    
+    private Connector connector;
+    
+    private Set<Authorizations> auths;
+    
+    private String metadataTable;
+    
+    private String modelTable;
+    
+    private String modelName;
+    
+    public Connector getConnector() {
+        return connector;
+    }
+    
+    public void setConnector(Connector connector) {
+        this.connector = connector;
+    }
+    
+    public Set<Authorizations> getAuths() {
+        return auths;
+    }
+    
+    public void setAuths(Set<Authorizations> authorizations) {
+        this.auths = authorizations;
+    }
+    
+    public String getMetadataTable() {
+        return metadataTable;
+    }
+    
+    public void setMetadataTable(String metadataTable) {
+        this.metadataTable = metadataTable;
+    }
+    
+    public String getModelTable() {
+        return modelTable;
+    }
+    
+    public void setModelTable(String modelTable) {
+        this.modelTable = modelTable;
+    }
+    
+    public String getModelName() {
+        return modelName;
+    }
+    
+    public void setModelName(String modelName) {
+        this.modelName = modelName;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConnectionConfig that = (ConnectionConfig) o;
+        return Objects.equals(connector, that.connector) && Objects.equals(auths, that.auths) && Objects.equals(metadataTable, that.metadataTable)
+                        && Objects.equals(modelTable, that.modelTable) && Objects.equals(modelName, that.modelName);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(connector, auths, metadataTable, modelTable, modelName);
+    }
+    
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).append("connector", connector).append("auths", auths).append("metadataTable", metadataTable)
+                        .append("modelTable", modelTable).append("modelName", modelName).toString();
+    }
+}

--- a/service/src/main/java/datawave/microservice/dictionary/data/DatawaveDataDictionary.java
+++ b/service/src/main/java/datawave/microservice/dictionary/data/DatawaveDataDictionary.java
@@ -18,11 +18,11 @@ public interface DatawaveDataDictionary<META extends MetadataFieldBase<META,DESC
     
     Collection<META> getFields(ConnectionConfig connectionConfig, Collection<String> dataTypeFilters, int numThreads) throws Exception;
     
-    void addDescription(ConnectionConfig connectionConfig, FIELD description) throws Exception;
+    void setDescription(ConnectionConfig connectionConfig, FIELD description) throws Exception;
     
-    void addDescription(ConnectionConfig connectionConfig, String fieldName, String datatype, DESC description) throws Exception;
+    void setDescription(ConnectionConfig connectionConfig, String fieldName, String datatype, DESC description) throws Exception;
     
-    void addDescriptions(ConnectionConfig connectionConfig, String fieldName, String datatype, Set<DESC> descriptions) throws Exception;
+    void setDescriptions(ConnectionConfig connectionConfig, String fieldName, String datatype, Set<DESC> descriptions) throws Exception;
     
     Multimap<Entry<String,String>,DESC> getDescriptions(ConnectionConfig connectionConfig) throws Exception;
     

--- a/service/src/main/java/datawave/microservice/dictionary/data/DatawaveDataDictionary.java
+++ b/service/src/main/java/datawave/microservice/dictionary/data/DatawaveDataDictionary.java
@@ -4,8 +4,6 @@ import com.google.common.collect.Multimap;
 import datawave.webservice.query.result.metadata.MetadataFieldBase;
 import datawave.webservice.results.datadictionary.DescriptionBase;
 import datawave.webservice.results.datadictionary.DictionaryFieldBase;
-import org.apache.accumulo.core.client.Connector;
-import org.apache.accumulo.core.security.Authorizations;
 
 import java.util.Collection;
 import java.util.Map;
@@ -13,31 +11,24 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 public interface DatawaveDataDictionary<META extends MetadataFieldBase<META,DESC>,DESC extends DescriptionBase<DESC>,FIELD extends DictionaryFieldBase<FIELD,DESC>> {
-    Collection<META> getFields(String modelName, String modelTableName, String metadataTableName, Collection<String> dataTypeFilters, Connector connector,
-                    Set<Authorizations> auths, int numThreads) throws Exception;
     
-    Map<String,String> getNormalizerMapping();
+    Map<String,String> getNormalizationMap();
     
-    void setNormalizerMapping(Map<String,String> normalizerMapping);
+    void setNormalizationMap(Map<String,String> normalizationMap);
     
-    void setDescription(Connector connector, String metadataTableName, Set<Authorizations> auths, String modelName, String modelTableName, FIELD description)
-                    throws Exception;
+    Collection<META> getFields(ConnectionConfig connectionConfig, Collection<String> dataTypeFilters, int numThreads) throws Exception;
     
-    void setDescription(Connector connector, String metadataTableName, Set<Authorizations> auths, String modelName, String modelTableName, String fieldName,
-                    String datatype, DESC description) throws Exception;
+    void addDescription(ConnectionConfig connectionConfig, FIELD description) throws Exception;
     
-    void setDescription(Connector connector, String metadataTableName, Set<Authorizations> auths, String modelName, String modelTableName, String fieldName,
-                    String datatype, Set<DESC> descriptions) throws Exception;
+    void addDescription(ConnectionConfig connectionConfig, String fieldName, String datatype, DESC description) throws Exception;
     
-    Multimap<Entry<String,String>,DESC> getDescriptions(Connector connector, String metadataTableName, Set<Authorizations> auths, String modelName,
-                    String modelTableName) throws Exception;
+    void addDescriptions(ConnectionConfig connectionConfig, String fieldName, String datatype, Set<DESC> descriptions) throws Exception;
     
-    Multimap<Entry<String,String>,DESC> getDescriptions(Connector connector, String metadataTableName, Set<Authorizations> auths, String modelName,
-                    String modelTableName, String datatype) throws Exception;
+    Multimap<Entry<String,String>,DESC> getDescriptions(ConnectionConfig connectionConfig) throws Exception;
     
-    Set<DESC> getDescriptions(Connector connector, String metadataTableName, Set<Authorizations> auths, String modelName, String modelTableName,
-                    String fieldName, String datatype) throws Exception;
+    Multimap<Entry<String,String>,DESC> getDescriptions(ConnectionConfig connectionConfig, String datatype) throws Exception;
     
-    void deleteDescription(Connector connector, String metadataTableName, Set<Authorizations> auths, String modelName, String modelTableName, String fieldName,
-                    String datatype, DESC description) throws Exception;
+    Set<DESC> getDescriptions(ConnectionConfig connectionConfig, String fieldName, String datatype) throws Exception;
+    
+    void deleteDescription(ConnectionConfig connectionConfig, String fieldName, String datatype, DESC description) throws Exception;
 }

--- a/service/src/main/java/datawave/microservice/dictionary/data/DatawaveDataDictionaryImpl.java
+++ b/service/src/main/java/datawave/microservice/dictionary/data/DatawaveDataDictionaryImpl.java
@@ -79,7 +79,7 @@ public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<Defaul
     }
     
     /**
-     * Add the specified description to the metadata table for the field name and data type combination supplied by the description.
+     * Set the specified description to the metadata table for the field name and data type combination supplied by the description.
      *
      * <p>
      *
@@ -91,12 +91,12 @@ public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<Defaul
      *            the description to add
      */
     @Override
-    public void addDescription(ConnectionConfig connectionConfig, DefaultDictionaryField description) throws Exception {
-        this.addDescriptions(connectionConfig, description.getFieldName(), description.getDatatype(), description.getDescriptions());
+    public void setDescription(ConnectionConfig connectionConfig, DefaultDictionaryField description) throws Exception {
+        this.setDescriptions(connectionConfig, description.getFieldName(), description.getDatatype(), description.getDescriptions());
     }
     
     /**
-     * Add the specified description to the metadata table for the specified field name and data type combination.
+     * Set the specified description to the metadata table for the specified field name and data type combination.
      *
      * <p>
      *
@@ -112,12 +112,12 @@ public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<Defaul
      *            the description to add
      */
     @Override
-    public void addDescription(ConnectionConfig connectionConfig, String fieldName, String datatype, DefaultDescription description) throws Exception {
-        addDescriptions(connectionConfig, fieldName, datatype, Collections.singleton(description));
+    public void setDescription(ConnectionConfig connectionConfig, String fieldName, String datatype, DefaultDescription description) throws Exception {
+        setDescriptions(connectionConfig, fieldName, datatype, Collections.singleton(description));
     }
     
     /**
-     * Add the specified descriptions to the metadata table for the specified field name and data type combination.
+     * Set the specified descriptions to the metadata table for the specified field name and data type combination.
      *
      * <p>
      *
@@ -133,7 +133,7 @@ public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<Defaul
      *            the descriptions to add
      */
     @Override
-    public void addDescriptions(ConnectionConfig connectionConfig, String fieldName, String datatype, Set<DefaultDescription> descriptions) throws Exception {
+    public void setDescriptions(ConnectionConfig connectionConfig, String fieldName, String datatype, Set<DefaultDescription> descriptions) throws Exception {
         // TODO - Consider skipping this. We check for an alias when retrieving descriptions or metadata fields anyway, rendering this unnecessary.
         String alias = getAlias(fieldName, connectionConfig);
         if (null != alias) {

--- a/service/src/main/java/datawave/microservice/dictionary/data/DatawaveDataDictionaryImpl.java
+++ b/service/src/main/java/datawave/microservice/dictionary/data/DatawaveDataDictionaryImpl.java
@@ -1,66 +1,39 @@
 package datawave.microservice.dictionary.data;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.SortedMap;
-
 import com.google.common.collect.HashMultimap;
-import datawave.data.ColumnFamilyConstants;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
 import datawave.marking.MarkingFunctions;
 import datawave.microservice.dictionary.config.ResponseObjectFactory;
+import datawave.microservice.metadata.DefaultMetadataFieldScanner;
 import datawave.microservice.metadata.MetadataDescriptionsHelper;
 import datawave.microservice.metadata.MetadataDescriptionsHelperFactory;
 import datawave.query.model.QueryModel;
 import datawave.query.util.MetadataEntry;
 import datawave.query.util.MetadataHelper;
 import datawave.query.util.MetadataHelperFactory;
-import datawave.security.util.ScannerHelper;
 import datawave.webservice.query.result.metadata.DefaultMetadataField;
 import datawave.webservice.results.datadictionary.DefaultDataDictionary;
 import datawave.webservice.results.datadictionary.DefaultDescription;
 import datawave.webservice.results.datadictionary.DefaultDictionaryField;
-
 import datawave.webservice.results.datadictionary.DefaultFields;
-import org.apache.accumulo.core.client.BatchScanner;
-import org.apache.accumulo.core.client.Connector;
-import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.data.Key;
-import org.apache.accumulo.core.data.Range;
-import org.apache.accumulo.core.data.Value;
-import org.apache.accumulo.core.iterators.user.WholeRowIterator;
-import org.apache.accumulo.core.security.Authorizations;
-import org.apache.accumulo.core.security.ColumnVisibility;
-import org.apache.hadoop.io.Text;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.CollectionUtils;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<DefaultMetadataField,DefaultDescription,DefaultDictionaryField> {
-    private static final Logger log = LoggerFactory.getLogger(DatawaveDataDictionaryImpl.class);
-    
-    private static final String DATE_FORMAT_STRING_TO_SECONDS = "yyyyMMddHHmmss";
-    private static final DateTimeFormatter DTF_Seconds = DateTimeFormat.forPattern(DATE_FORMAT_STRING_TO_SECONDS);
-    
-    private Map<String,String> normalizerMapping = Maps.newHashMap();
     
     private final MarkingFunctions markingFunctions;
     private final ResponseObjectFactory<DefaultDescription,DefaultDataDictionary,DefaultMetadataField,DefaultDictionaryField,DefaultFields> responseObjectFactory;
     private final MetadataHelperFactory metadataHelperFactory;
     private final MetadataDescriptionsHelperFactory<DefaultDescription> metadataDescriptionsHelperFactory;
+    private Map<String,String> normalizationMap = Maps.newHashMap();
     
     public DatawaveDataDictionaryImpl(MarkingFunctions markingFunctions,
                     ResponseObjectFactory<DefaultDescription,DefaultDataDictionary,DefaultMetadataField,DefaultDictionaryField,DefaultFields> responseObjectFactory,
@@ -72,337 +45,256 @@ public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<Defaul
     }
     
     @Override
-    public Map<String,String> getNormalizerMapping() {
-        return normalizerMapping;
+    public Map<String,String> getNormalizationMap() {
+        return normalizationMap;
     }
     
     @Override
-    public void setNormalizerMapping(Map<String,String> normalizerMapping) {
-        this.normalizerMapping = normalizerMapping;
+    public void setNormalizationMap(Map<String,String> normalizationMap) {
+        this.normalizationMap = normalizationMap;
     }
     
-    /*
-     * (non-Javadoc)
+    /**
+     * Retrieve metadata fields from the specified metadata table, aggregated by field name and data type.
      *
-     * Note: dataTypeFilters can be empty, which means all the fields will be returned
+     * <p/>
+     *
+     * If no data types are specified, then all metadata fields are returned. Otherwise, only metadata fields with one of the specified data types will be
+     * returned.
+     *
+     * @param connectionConfig
+     *            the connection configuration to use when connecting to accumulo
+     * @param dataTypeFilters
+     *            the set of data types to filter on
+     * @param numThreads
+     *            the number of threads to use when scanning the metadata table
+     * @return a collection of metadata fields
      */
     @Override
-    public Collection<DefaultMetadataField> getFields(String modelName, String modelTableName, String metadataTableName, Collection<String> dataTypeFilters,
-                    Connector connector, Set<Authorizations> auths, int numThreads) throws Exception {
-        // Get a MetadataHelper
-        MetadataHelper metadataHelper = metadataHelperFactory.createMetadataHelper(connector, metadataTableName, auths);
-        // So we can get a QueryModel
-        QueryModel queryModel = metadataHelper.getQueryModel(modelTableName, modelName, metadataHelper.getIndexOnlyFields(null));
-        
-        Map<String,String> reverseMapping;
-        
-        // So we can pull the reverse mapping for this model
-        if (null != queryModel) {
-            reverseMapping = queryModel.getReverseQueryMapping();
-        } else {
-            reverseMapping = Collections.emptyMap();
-        }
-        
-        // Fetch the results from Accumulo
-        BatchScanner bs = fetchResults(connector, metadataTableName, auths, numThreads);
-        
-        // Convert them into a response object
-        Collection<DefaultMetadataField> fields = transformResults(bs.iterator(), reverseMapping, dataTypeFilters);
-        
-        // Close the BatchScanner and return the Accumulo connector
-        bs.close();
-        
-        // Convert them into the DataDictionary response object
-        return fields;
+    public Collection<DefaultMetadataField> getFields(ConnectionConfig connectionConfig, Collection<String> dataTypeFilters, int numThreads) throws Exception {
+        Map<String,String> aliases = getAliases(connectionConfig);
+        DefaultMetadataFieldScanner scanner = new DefaultMetadataFieldScanner(markingFunctions, responseObjectFactory, normalizationMap, connectionConfig,
+                        numThreads);
+        return scanner.getFields(aliases, dataTypeFilters);
     }
     
-    private BatchScanner fetchResults(Connector connector, String metadataTableName, Set<Authorizations> auths, int numThreads) throws TableNotFoundException {
-        BatchScanner bs = ScannerHelper.createBatchScanner(connector, metadataTableName, auths, numThreads);
-        bs.addScanIterator(new IteratorSetting(21, WholeRowIterator.class));
-        bs.setRanges(Collections.singletonList(new Range()));
-        bs.fetchColumnFamily(ColumnFamilyConstants.COLF_E);
-        bs.fetchColumnFamily(ColumnFamilyConstants.COLF_I);
-        bs.fetchColumnFamily(ColumnFamilyConstants.COLF_RI);
-        bs.fetchColumnFamily(ColumnFamilyConstants.COLF_DESC);
-        bs.fetchColumnFamily(ColumnFamilyConstants.COLF_H);
-        bs.fetchColumnFamily(ColumnFamilyConstants.COLF_T);
-        bs.fetchColumnFamily(ColumnFamilyConstants.COLF_TF);
-        
-        return bs;
-    }
-    
-    private Collection<DefaultMetadataField> transformResults(Iterator<Entry<Key,Value>> iterator, Map<String,String> reverseMapping,
-                    Collection<String> dataTypeFilters) {
-        HashMap<String,Map<String,DefaultMetadataField>> fieldMap = Maps.newHashMap();
-        boolean shouldNotFilterDataTypes = CollectionUtils.isEmpty(dataTypeFilters);
-        
-        final Text holder = new Text(), row = new Text();
-        
-        // Each Entry is the entire row
-        while (iterator.hasNext()) {
-            Entry<Key,Value> entry = iterator.next();
-            
-            try {
-                // Handle batch scanner bug
-                if (entry.getKey() == null && entry.getValue() == null)
-                    return null;
-                if (null == entry.getKey() || null == entry.getValue()) {
-                    throw new IllegalArgumentException("Null key or value. Key:" + entry.getKey() + ", Value: " + entry.getValue());
-                }
-                
-                SortedMap<Key,Value> rowEntries = WholeRowIterator.decodeRow(entry.getKey(), entry.getValue());
-                for (Entry<Key,Value> rowEntry : rowEntries.entrySet()) {
-                    Key key = rowEntry.getKey();
-                    Value value = rowEntry.getValue();
-                    key.getRow(row);
-                    key.getColumnFamily(holder);
-                    
-                    // If event should be hidden skip
-                    if (ColumnFamilyConstants.COLF_H.equals(holder)) {
-                        fieldMap.remove(row.toString());
-                        break;
-                    }
-                    
-                    String cq = key.getColumnQualifier().toString();
-                    int nullPos = cq.indexOf('\0');
-                    String dataType = (nullPos < 0) ? cq : cq.substring(0, nullPos);
-                    if (shouldNotFilterDataTypes || dataTypeFilters.contains(dataType)) {
-                        DefaultMetadataField field = getFieldForDatatype(row.toString(), dataType, fieldMap);
-                        
-                        if (ColumnFamilyConstants.COLF_E.equals(holder)) {
-                            field.setIndexOnly(false);
-                            String fieldName = key.getRow().toString();
-                            if (reverseMapping.containsKey(fieldName)) {
-                                field.setFieldName(reverseMapping.get(fieldName));
-                                field.setInternalFieldName(fieldName);
-                            } else {
-                                field.setFieldName(fieldName);
-                            }
-                            field.setLastUpdated(parseTimestamp(key.getTimestamp()));
-                        } else if (ColumnFamilyConstants.COLF_I.equals(holder)) {
-                            field.setForwardIndexed(true);
-                        } else if (ColumnFamilyConstants.COLF_RI.equals(holder)) {
-                            field.setReverseIndexed(true);
-                        } else if (ColumnFamilyConstants.COLF_DESC.equals(holder)) {
-                            DefaultDescription desc = this.responseObjectFactory.getDescription();
-                            desc.setDescription(value.toString());
-                            desc.setMarkings(getMarkings(key));
-                            field.getDescriptions().add(desc);
-                        } else if (ColumnFamilyConstants.COLF_T.equals(holder)) {
-                            field.addType(translate(cq.substring(nullPos + 1)));
-                        } else if (ColumnFamilyConstants.COLF_TF.equals(holder)) {
-                            field.setTokenized(true);
-                        } else {
-                            log.warn("Unknown entry with key=" + key + ", value=" + value);
-                        }
-                        
-                        // Handle index-only fields, which have no "e" entry
-                        if (field.getFieldName() == null) {
-                            String fieldName = key.getRow().toString();
-                            if (reverseMapping.containsKey(fieldName)) {
-                                field.setFieldName(reverseMapping.get(fieldName));
-                                field.setInternalFieldName(fieldName);
-                            } else {
-                                field.setFieldName(fieldName);
-                            }
-                        }
-                        
-                        // Determine the lastUpdated value for index-only fields without including timestamps from description rows.
-                        if (field.isIndexOnly() && field.getLastUpdated() == null && !ColumnFamilyConstants.COLF_DESC.equals(holder)) {
-                            field.setLastUpdated(parseTimestamp(key.getTimestamp()));
-                        }
-                    }
-                    
-                }
-            } catch (IOException e) {
-                throw new IllegalStateException("Unable to decode row " + entry.getKey());
-            } catch (MarkingFunctions.Exception e) {
-                throw new IllegalStateException("Unable to decode visibility " + entry.getKey(), e);
-            }
-        }
-        
-        Collection<Map<String,DefaultMetadataField>> datatypesForField = fieldMap.values();
-        LinkedList<DefaultMetadataField> fields = Lists.newLinkedList();
-        for (Map<String,DefaultMetadataField> value : datatypesForField) {
-            fields.addAll(value.values());
-        }
-        
-        return fields;
-    }
-    
-    private String parseTimestamp(long inMillis) {
-        return DTF_Seconds.print(inMillis);
-    }
-    
-    private DefaultMetadataField getFieldForDatatype(String fieldName, String dataType, HashMap<String,Map<String,DefaultMetadataField>> fieldMap) {
-        Map<String,DefaultMetadataField> allTypesForField = fieldMap.computeIfAbsent(fieldName, k -> Maps.newHashMap());
-        
-        DefaultMetadataField field = allTypesForField.get(dataType);
-        
-        if (field == null) {
-            field = new DefaultMetadataField();
-            field.setIndexOnly(true); // default fields to index-only, and we'll clear if we see an "e" entry for the field
-            field.setDataType(dataType);
-            allTypesForField.put(dataType, field);
-        }
-        
-        return field;
-    }
-    
-    public String translate(String normalizer) {
-        if (normalizerMapping.containsKey(normalizer)) {
-            String type = normalizerMapping.get(normalizer);
-            if (null != type) {
-                return type;
-            }
-        }
-        
-        return "Unknown";
-    }
-    
+    /**
+     * Add the specified description to the metadata table for the field name and data type combination supplied by the description.
+     *
+     * <p>
+     *
+     * If an alias exists for the given field name, that alias will be used when adding the description.
+     *
+     * @param connectionConfig
+     *            the connection configuration to use when connecting to accumulo
+     * @param description
+     *            the description to add
+     */
     @Override
-    public void setDescription(Connector connector, String metadataTableName, Set<Authorizations> auths, String modelName, String modelTableName,
-                    DefaultDictionaryField description) throws Exception {
-        this.setDescription(connector, metadataTableName, auths, modelName, modelTableName, description.getFieldName(), description.getDatatype(),
-                        description.getDescriptions());
+    public void addDescription(ConnectionConfig connectionConfig, DefaultDictionaryField description) throws Exception {
+        this.addDescriptions(connectionConfig, description.getFieldName(), description.getDatatype(), description.getDescriptions());
     }
     
+    /**
+     * Add the specified description to the metadata table for the specified field name and data type combination.
+     *
+     * <p>
+     *
+     * If an alias exists for the given field name, that alias will be used when adding the description.
+     *
+     * @param connectionConfig
+     *            the connection configuration to use when connecting to accumulo
+     * @param fieldName
+     *            the field name
+     * @param datatype
+     *            the data type
+     * @param description
+     *            the description to add
+     */
     @Override
-    public void setDescription(Connector connector, String metadataTableName, Set<Authorizations> auths, String modelName, String modelTable, String fieldName,
-                    String datatype, DefaultDescription desc) throws Exception {
-        setDescription(connector, metadataTableName, auths, modelName, modelTable, fieldName, datatype, Collections.singleton(desc));
+    public void addDescription(ConnectionConfig connectionConfig, String fieldName, String datatype, DefaultDescription description) throws Exception {
+        addDescriptions(connectionConfig, fieldName, datatype, Collections.singleton(description));
     }
     
+    /**
+     * Add the specified descriptions to the metadata table for the specified field name and data type combination.
+     *
+     * <p>
+     *
+     * If an alias exists for the given field name, that alias will be used when adding the descriptions.
+     *
+     * @param connectionConfig
+     *            the connection configuration to use when connecting to accumulo
+     * @param fieldName
+     *            the field name
+     * @param datatype
+     *            the data type
+     * @param descriptions
+     *            the descriptions to add
+     */
     @Override
-    public void setDescription(Connector connector, String metadataTableName, Set<Authorizations> auths, String modelName, String modelTable, String fieldName,
-                    String datatype, Set<DefaultDescription> descs) throws Exception {
-        MetadataHelper helper = metadataHelperFactory.createMetadataHelper(connector, metadataTableName, auths);
-        
-        QueryModel model = helper.getQueryModel(modelTable, modelName);
-        Map<String,String> mapping = reverseReverseMapping(model);
-        String alias = mapping.get(fieldName);
-        
+    public void addDescriptions(ConnectionConfig connectionConfig, String fieldName, String datatype, Set<DefaultDescription> descriptions) throws Exception {
+        // TODO - Consider skipping this. We check for an alias when retrieving descriptions or metadata fields anyway, rendering this unnecessary.
+        String alias = getAlias(fieldName, connectionConfig);
         if (null != alias) {
             fieldName = alias;
         }
         
         // TODO The query model is effectively busted because it doesn't uniquely reference field+datatype
         MetadataEntry mentry = new MetadataEntry(fieldName, datatype);
-        
-        MetadataDescriptionsHelper<DefaultDescription> descriptionsHelper = getInitializedDescriptionsHelper(connector, metadataTableName, auths);
-        descriptionsHelper.setDescriptions(mentry, descs);
+        MetadataDescriptionsHelper<DefaultDescription> helper = getInitializedDescriptionsHelper(connectionConfig);
+        helper.setDescriptions(mentry, descriptions);
     }
     
+    /**
+     * Retrieve all descriptions for metadata field entries.
+     *
+     * <p/>
+     *
+     * If an alias exists for the given field name, that alias will be used when attempting to retrieve the descriptions.
+     *
+     * @param connectionConfig
+     *            the connection configuration to use when connecting to accumulo
+     * @return a {@link Multimap} with {@literal <fieldName, dataType>} entry keys mapped to their associated descriptions
+     */
     @Override
-    public Multimap<Entry<String,String>,DefaultDescription> getDescriptions(Connector connector, String metadataTableName, Set<Authorizations> auths,
-                    String modelName, String modelTable) throws Exception {
-        MetadataHelper helper = metadataHelperFactory.createMetadataHelper(connector, metadataTableName, auths);
-        QueryModel model = helper.getQueryModel(modelTable, modelName);
-        Map<String,String> mapping = model.getReverseQueryMapping();
-        
-        MetadataDescriptionsHelper<DefaultDescription> descriptionsHelper = getInitializedDescriptionsHelper(connector, metadataTableName, auths);
+    public Multimap<Entry<String,String>,DefaultDescription> getDescriptions(ConnectionConfig connectionConfig) throws Exception {
+        MetadataDescriptionsHelper<DefaultDescription> descriptionsHelper = getInitializedDescriptionsHelper(connectionConfig);
         Multimap<MetadataEntry,DefaultDescription> descriptions = descriptionsHelper.getDescriptions((Set<String>) null);
-        Multimap<Entry<String,String>,DefaultDescription> tformDescriptions = HashMultimap.create();
-        
+        return transformKeys(descriptions, connectionConfig);
+    }
+    
+    /**
+     * Retrieves all descriptions for metadata entries with the specified data type.
+     *
+     * <p/>
+     *
+     * If an alias exists for the given field name, that alias will be used when attempting to retrieve the descriptions.
+     *
+     * @param connectionConfig
+     *            the connection configuration to use when connecting to accumulo
+     * @param datatype
+     *            the data type
+     * @return a {@link Multimap} with {@literal <fieldName, dataType>} entry keys mapped to their associated descriptions
+     */
+    @Override
+    public Multimap<Entry<String,String>,DefaultDescription> getDescriptions(ConnectionConfig connectionConfig, String datatype) throws Exception {
+        MetadataDescriptionsHelper<DefaultDescription> helper = getInitializedDescriptionsHelper(connectionConfig);
+        Multimap<MetadataEntry,DefaultDescription> descriptions = helper.getDescriptions(datatype);
+        return transformKeys(descriptions, connectionConfig);
+    }
+    
+    /**
+     * Retrieves all descriptions for metadata entries with the specified field name and data type combination.
+     *
+     * <p/>
+     *
+     * If an alias exists for the given field name, that alias will be used when attempting to retrieve the descriptions.
+     *
+     * @param connectionConfig
+     *            the connection configuration to use when connecting to accumulo
+     * @param fieldName
+     *            the field name
+     * @param datatype
+     *            the data type
+     * @return the descriptions
+     */
+    @Override
+    public Set<DefaultDescription> getDescriptions(ConnectionConfig connectionConfig, String fieldName, String datatype) throws Exception {
+        String alias = getAlias(fieldName, connectionConfig);
+        MetadataDescriptionsHelper<DefaultDescription> helper = getInitializedDescriptionsHelper(connectionConfig);
+        return alias == null ? helper.getDescriptions(fieldName, datatype) : helper.getDescriptions(alias, datatype);
+    }
+    
+    /**
+     * Deletes the specified description for the specified field name and data type combination.
+     *
+     * <p/>
+     *
+     * If an alias exists for the given field name, that alias will be used when attempting to delete the description.
+     *
+     * @param connectionConfig
+     *            the connection configuration to use when connecting to accumulo
+     * @param fieldName
+     *            the field name
+     * @param datatype
+     *            the data type
+     * @param description
+     *            the description to delete
+     */
+    @Override
+    public void deleteDescription(ConnectionConfig connectionConfig, String fieldName, String datatype, DefaultDescription description) throws Exception {
+        String alias = getAlias(fieldName, connectionConfig);
+        if (alias != null) {
+            fieldName = alias;
+        }
+        MetadataDescriptionsHelper<DefaultDescription> descriptionsHelper = getInitializedDescriptionsHelper(connectionConfig);
+        descriptionsHelper.removeDescription(new MetadataEntry(fieldName, datatype), description);
+    }
+    
+    /**
+     * Transform the {@link MetadataEntry} key of the specified map into {@link <fieldName,dataType>} entries.
+     *
+     * <p>
+     *
+     * If an alias exists for a field name, that alias will be returned instead of the field name.
+     *
+     * @param descriptions
+     *            the descriptions to transform
+     * @param connectionConfig
+     *            the connection config to use when retrieving the aliases
+     * @return the transformed map
+     */
+    private Multimap<Entry<String,String>,DefaultDescription> transformKeys(Multimap<MetadataEntry,DefaultDescription> descriptions,
+                    ConnectionConfig connectionConfig) throws ExecutionException, TableNotFoundException {
+        Map<String,String> aliases = getAliases(connectionConfig);
+        Multimap<Entry<String,String>,DefaultDescription> transformedDescriptions = HashMultimap.create();
         for (Entry<MetadataEntry,DefaultDescription> entry : descriptions.entries()) {
-            MetadataEntry mentry = entry.getKey();
-            
-            String alias = mapping.get(mentry.getFieldName());
-            
-            if (null == alias) {
+            MetadataEntry metadataEntry = entry.getKey();
+            String alias = aliases.get(metadataEntry.getFieldName());
+            if (alias == null) {
                 // TODO The query model is effectively busted because it doesn't uniquely reference field+datatype
-                tformDescriptions.put(entry.getKey().toEntry(), entry.getValue());
+                transformedDescriptions.put(metadataEntry.toEntry(), entry.getValue());
             } else {
-                tformDescriptions.put(Maps.immutableEntry(alias, mentry.getDatatype()), entry.getValue());
+                transformedDescriptions.put(Maps.immutableEntry(alias, metadataEntry.getDatatype()), entry.getValue());
             }
         }
-        
-        return tformDescriptions;
+        return transformedDescriptions;
     }
     
-    @Override
-    public Multimap<Entry<String,String>,DefaultDescription> getDescriptions(Connector connector, String metadataTableName, Set<Authorizations> auths,
-                    String modelName, String modelTable, String datatype) throws Exception {
-        MetadataHelper helper = metadataHelperFactory.createMetadataHelper(connector, metadataTableName, auths);
-        QueryModel model = helper.getQueryModel(modelTable, modelName);
-        Map<String,String> mapping = model.getReverseQueryMapping();
-        
-        MetadataDescriptionsHelper<DefaultDescription> descriptionsHelper = getInitializedDescriptionsHelper(connector, metadataTableName, auths);
-        Multimap<MetadataEntry,DefaultDescription> descriptions = descriptionsHelper.getDescriptions(datatype);
-        Multimap<Entry<String,String>,DefaultDescription> tformDescriptions = HashMultimap.create();
-        
-        for (Entry<MetadataEntry,DefaultDescription> entry : descriptions.entries()) {
-            MetadataEntry mentry = entry.getKey();
-            
-            String alias = mapping.get(mentry.getFieldName());
-            
-            if (null == alias) {
-                // TODO The query model is effectively busted because it doesn't uniquely reference field+datatype
-                tformDescriptions.put(entry.getKey().toEntry(), entry.getValue());
-            } else {
-                tformDescriptions.put(Maps.immutableEntry(alias, mentry.getDatatype()), entry.getValue());
-            }
-        }
-        
-        return tformDescriptions;
-    }
-    
-    @Override
-    public Set<DefaultDescription> getDescriptions(Connector connector, String metadataTableName, Set<Authorizations> auths, String modelName,
-                    String modelTable, String fieldName, String datatype) throws Exception {
-        MetadataHelper helper = metadataHelperFactory.createMetadataHelper(connector, metadataTableName, auths);
-        QueryModel model = helper.getQueryModel(modelTable, modelName);
-        Map<String,String> mapping = reverseReverseMapping(model);
-        
-        String alias = mapping.get(fieldName);
-        
-        MetadataDescriptionsHelper<DefaultDescription> descriptionsHelper = getInitializedDescriptionsHelper(connector, metadataTableName, auths);
-        if (null == alias) {
-            return descriptionsHelper.getDescriptions(fieldName, datatype);
-        } else {
-            return descriptionsHelper.getDescriptions(alias, datatype);
-        }
-    }
-    
-    @Override
-    public void deleteDescription(Connector connector, String metadataTableName, Set<Authorizations> auths, String modelName, String modelTable,
-                    String fieldName, String datatype, DefaultDescription desc) throws Exception {
-        MetadataHelper helper = metadataHelperFactory.createMetadataHelper(connector, metadataTableName, auths);
-        QueryModel model = helper.getQueryModel(modelTable, modelName);
-        Map<String,String> mapping = reverseReverseMapping(model);
-        
-        String alias = mapping.get(fieldName);
-        
-        MetadataDescriptionsHelper<DefaultDescription> descriptionsHelper = getInitializedDescriptionsHelper(connector, metadataTableName, auths);
-        if (null == alias) {
-            descriptionsHelper.removeDescription(new MetadataEntry(fieldName, datatype), desc);
-        } else {
-            descriptionsHelper.removeDescription(new MetadataEntry(alias, datatype), desc);
-        }
-    }
-    
-    private MetadataDescriptionsHelper<DefaultDescription> getInitializedDescriptionsHelper(Connector connector, String metadataTableName,
-                    Set<Authorizations> auths) {
+    /**
+     * Return a new, initialized {@link MetadataDescriptionsHelper}
+     *
+     * @param connectionConfig
+     *            the connection configuration to use when initializing the helper
+     * @return the {@link MetadataDescriptionsHelper}
+     */
+    private MetadataDescriptionsHelper<DefaultDescription> getInitializedDescriptionsHelper(ConnectionConfig connectionConfig) {
         MetadataDescriptionsHelper<DefaultDescription> helper = metadataDescriptionsHelperFactory.createMetadataDescriptionsHelper();
-        helper.initialize(connector, metadataTableName, auths);
+        helper.initialize(connectionConfig.getConnector(), connectionConfig.getMetadataTable(), connectionConfig.getAuths());
         return helper;
     }
     
-    private Map<String,String> reverseReverseMapping(QueryModel model) {
-        Map<String,String> reverseMapping = model.getReverseQueryMapping();
-        Map<String,String> reversed = Maps.newHashMap();
-        
-        for (Entry<String,String> entry : reverseMapping.entrySet()) {
-            reversed.put(entry.getValue(), entry.getKey());
-        }
-        return reversed;
+    /**
+     * Return the alias map for the query model in the specified connection config.
+     *
+     * @return the alias map, or an empty map if no query model exists
+     */
+    private Map<String,String> getAliases(ConnectionConfig connectionConfig) throws ExecutionException, TableNotFoundException {
+        MetadataHelper helper = metadataHelperFactory.createMetadataHelper(connectionConfig.getConnector(), connectionConfig.getMetadataTable(),
+                        connectionConfig.getAuths());
+        QueryModel model = helper.getQueryModel(connectionConfig.getModelTable(), connectionConfig.getModelName());
+        return model != null ? model.getReverseQueryMapping() : Collections.emptyMap();
     }
     
-    private Map<String,String> getMarkings(Key k) throws MarkingFunctions.Exception {
-        return getMarkings(k.getColumnVisibilityParsed());
-    }
-    
-    private Map<String,String> getMarkings(ColumnVisibility visibility) throws MarkingFunctions.Exception {
-        return markingFunctions.translateFromColumnVisibility(visibility);
+    /**
+     * Retrieve the alias for the specified field name from the alias map for the specified field name.
+     *
+     * @return the alias, or null if no alias exists
+     */
+    private String getAlias(String fieldName, ConnectionConfig connectionConfig) throws ExecutionException, TableNotFoundException {
+        Map<String,String> map = getAliases(connectionConfig);
+        Map<String,String> reversedMap = map.entrySet().stream().collect(Collectors.toMap(Entry::getValue, Entry::getKey));
+        return reversedMap.get(fieldName);
     }
 }

--- a/service/src/main/java/datawave/microservice/dictionary/data/DatawaveDataDictionaryImpl.java
+++ b/service/src/main/java/datawave/microservice/dictionary/data/DatawaveDataDictionaryImpl.java
@@ -57,7 +57,7 @@ public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<Defaul
     /**
      * Retrieve metadata fields from the specified metadata table, aggregated by field name and data type.
      *
-     * <p/>
+     * <p>
      *
      * If no data types are specified, then all metadata fields are returned. Otherwise, only metadata fields with one of the specified data types will be
      * returned.
@@ -149,7 +149,7 @@ public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<Defaul
     /**
      * Retrieve all descriptions for metadata field entries.
      *
-     * <p/>
+     * <p>
      *
      * If an alias exists for the given field name, that alias will be used when attempting to retrieve the descriptions.
      *
@@ -167,7 +167,7 @@ public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<Defaul
     /**
      * Retrieves all descriptions for metadata entries with the specified data type.
      *
-     * <p/>
+     * <p>
      *
      * If an alias exists for the given field name, that alias will be used when attempting to retrieve the descriptions.
      *
@@ -187,7 +187,7 @@ public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<Defaul
     /**
      * Retrieves all descriptions for metadata entries with the specified field name and data type combination.
      *
-     * <p/>
+     * <p>
      *
      * If an alias exists for the given field name, that alias will be used when attempting to retrieve the descriptions.
      *
@@ -209,7 +209,7 @@ public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<Defaul
     /**
      * Deletes the specified description for the specified field name and data type combination.
      *
-     * <p/>
+     * <p>
      *
      * If an alias exists for the given field name, that alias will be used when attempting to delete the description.
      *
@@ -232,19 +232,8 @@ public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<Defaul
         descriptionsHelper.removeDescription(new MetadataEntry(fieldName, datatype), description);
     }
     
-    /**
-     * Transform the {@link MetadataEntry} key of the specified map into {@link <fieldName,dataType>} entries.
-     *
-     * <p>
-     *
-     * If an alias exists for a field name, that alias will be returned instead of the field name.
-     *
-     * @param descriptions
-     *            the descriptions to transform
-     * @param connectionConfig
-     *            the connection config to use when retrieving the aliases
-     * @return the transformed map
-     */
+    // Transform the MetadataEntry key of the specified map into <fieldName,dataType> entries.
+    // If an alias exists for a field name, that alias will be returned instead of the field name.
     private Multimap<Entry<String,String>,DefaultDescription> transformKeys(Multimap<MetadataEntry,DefaultDescription> descriptions,
                     ConnectionConfig connectionConfig) throws ExecutionException, TableNotFoundException {
         Map<String,String> aliases = getAliases(connectionConfig);
@@ -262,24 +251,14 @@ public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<Defaul
         return transformedDescriptions;
     }
     
-    /**
-     * Return a new, initialized {@link MetadataDescriptionsHelper}
-     *
-     * @param connectionConfig
-     *            the connection configuration to use when initializing the helper
-     * @return the {@link MetadataDescriptionsHelper}
-     */
+    // Return a new, initialized metadata description helper.
     private MetadataDescriptionsHelper<DefaultDescription> getInitializedDescriptionsHelper(ConnectionConfig connectionConfig) {
         MetadataDescriptionsHelper<DefaultDescription> helper = metadataDescriptionsHelperFactory.createMetadataDescriptionsHelper();
         helper.initialize(connectionConfig.getConnector(), connectionConfig.getMetadataTable(), connectionConfig.getAuths());
         return helper;
     }
     
-    /**
-     * Return the alias map for the query model in the specified connection config.
-     *
-     * @return the alias map, or an empty map if no query model exists
-     */
+    // Return the alias map for the query model in the specified connection config.
     private Map<String,String> getAliases(ConnectionConfig connectionConfig) throws ExecutionException, TableNotFoundException {
         MetadataHelper helper = metadataHelperFactory.createMetadataHelper(connectionConfig.getConnector(), connectionConfig.getMetadataTable(),
                         connectionConfig.getAuths());
@@ -287,11 +266,7 @@ public class DatawaveDataDictionaryImpl implements DatawaveDataDictionary<Defaul
         return model != null ? model.getReverseQueryMapping() : Collections.emptyMap();
     }
     
-    /**
-     * Retrieve the alias for the specified field name from the alias map for the specified field name.
-     *
-     * @return the alias, or null if no alias exists
-     */
+    // Retrieve the alias for the specified field name from the alias map for the specified field name.
     private String getAlias(String fieldName, ConnectionConfig connectionConfig) throws ExecutionException, TableNotFoundException {
         Map<String,String> map = getAliases(connectionConfig);
         Map<String,String> reversedMap = map.entrySet().stream().collect(Collectors.toMap(Entry::getValue, Entry::getKey));

--- a/service/src/main/java/datawave/microservice/metadata/DefaultMetadataFieldScanner.java
+++ b/service/src/main/java/datawave/microservice/metadata/DefaultMetadataFieldScanner.java
@@ -1,0 +1,294 @@
+package datawave.microservice.metadata;
+
+import com.google.common.collect.Maps;
+import datawave.data.ColumnFamilyConstants;
+import datawave.marking.MarkingFunctions;
+import datawave.microservice.dictionary.config.ResponseObjectFactory;
+import datawave.microservice.dictionary.data.ConnectionConfig;
+import datawave.security.util.ScannerHelper;
+import datawave.webservice.query.result.metadata.DefaultMetadataField;
+import datawave.webservice.results.datadictionary.DefaultDataDictionary;
+import datawave.webservice.results.datadictionary.DefaultDescription;
+import datawave.webservice.results.datadictionary.DefaultDictionaryField;
+import datawave.webservice.results.datadictionary.DefaultFields;
+import org.apache.accumulo.core.client.BatchScanner;
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.data.Range;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.iterators.user.WholeRowIterator;
+import org.apache.hadoop.io.Text;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.stream.Collectors;
+
+public class DefaultMetadataFieldScanner {
+    
+    private static final Logger log = LoggerFactory.getLogger(DefaultMetadataFieldScanner.class);
+    private static final String TIMESTAMP_FORMAT = "yyyyMMddHHmmss";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern(TIMESTAMP_FORMAT);
+    
+    private final MarkingFunctions markingFunctions;
+    private final ResponseObjectFactory<DefaultDescription,?,DefaultMetadataField,?,?> responseObjectFactory;
+    private final Map<String,String> normalizationMap;
+    private final ConnectionConfig connectionConfig;
+    private final int numThreads;
+    
+    public DefaultMetadataFieldScanner(MarkingFunctions markingFunctions,
+                    ResponseObjectFactory<DefaultDescription,DefaultDataDictionary,DefaultMetadataField,DefaultDictionaryField,DefaultFields> responseObjectFactory,
+                    Map<String,String> normalizationMap, ConnectionConfig connectionConfig, int numThreads) {
+        this.markingFunctions = markingFunctions;
+        this.responseObjectFactory = responseObjectFactory;
+        this.normalizationMap = normalizationMap;
+        this.connectionConfig = connectionConfig;
+        this.numThreads = numThreads;
+    }
+    
+    public Collection<DefaultMetadataField> getFields(Map<String,String> aliases, Collection<String> datatypeFilters) throws TableNotFoundException {
+        BatchScanner scanner = createScanner();
+        Transformer transformer = new Transformer(scanner.iterator(), aliases, datatypeFilters);
+        Collection<DefaultMetadataField> fields = transformer.transform();
+        scanner.close();
+        return fields;
+    }
+    
+    /**
+     * Create and return a scanner that will aggregate metadata entries by their row.
+     * 
+     * @return the scanner
+     */
+    private BatchScanner createScanner() throws TableNotFoundException {
+        BatchScanner scanner = ScannerHelper.createBatchScanner(connectionConfig.getConnector(), connectionConfig.getMetadataTable(),
+                        connectionConfig.getAuths(), numThreads);
+        // Ensure rows for the same field are grouped into a single iterator entry.
+        scanner.addScanIterator(new IteratorSetting(21, WholeRowIterator.class));
+        // Do not limit the scanner based on ranges.
+        scanner.setRanges(Collections.singletonList(new Range()));
+        scanner.fetchColumnFamily(ColumnFamilyConstants.COLF_E);
+        scanner.fetchColumnFamily(ColumnFamilyConstants.COLF_I);
+        scanner.fetchColumnFamily(ColumnFamilyConstants.COLF_RI);
+        scanner.fetchColumnFamily(ColumnFamilyConstants.COLF_DESC);
+        scanner.fetchColumnFamily(ColumnFamilyConstants.COLF_H);
+        scanner.fetchColumnFamily(ColumnFamilyConstants.COLF_T);
+        scanner.fetchColumnFamily(ColumnFamilyConstants.COLF_TF);
+        return scanner;
+    }
+    
+    private class Transformer {
+        
+        private final Iterator<Map.Entry<Key,Value>> iterator;
+        private final Map<String,String> aliases;
+        private final Collection<String> dataTypeFilters;
+        private final boolean acceptAllDataTypes;
+        
+        private final Map<String,Map<String,DefaultMetadataField>> fields; // Map of field names to data types to transformed fields.
+        private final Text currRow = new Text(); // Used to copy the current row into.
+        private final Text currColumnFamily = new Text(); // Used to copy the current column family into.
+        
+        private Key currKey;
+        private Value currValue;
+        private String currColumnQualifier;
+        private DefaultMetadataField currField;
+        
+        private Transformer(Iterator<Map.Entry<Key,Value>> iterator, Map<String,String> aliases, Collection<String> dataTypeFilters) {
+            this.iterator = iterator;
+            this.aliases = aliases;
+            this.dataTypeFilters = dataTypeFilters;
+            this.acceptAllDataTypes = dataTypeFilters.isEmpty();
+            fields = new HashMap<>();
+        }
+        
+        /**
+         * Transform the iterator entries into {@link DefaultMetadataField} and return them.
+         * 
+         * @return the transformed fields
+         */
+        private Collection<DefaultMetadataField> transform() {
+            while (iterator.hasNext()) {
+                Map.Entry<Key,Value> entry = iterator.next();
+                try {
+                    // Handles a batch scanner bug where an entry with a null key and value may be in the iterator.
+                    if (entry.getKey() == null && entry.getValue() == null)
+                        // TODO - return an empty collection instead to avoid NPE?
+                        return null;
+                    // Check if either the key or value are null, and throw an exception if so.
+                    if (null == entry.getKey() || null == entry.getValue()) {
+                        throw new IllegalArgumentException("Null key or value. Key:" + entry.getKey() + ", Value: " + entry.getValue());
+                    }
+                    transformEntry(entry);
+                } catch (IOException e) {
+                    throw new IllegalStateException("Unable to decode row " + entry.getKey());
+                } catch (MarkingFunctions.Exception e) {
+                    throw new IllegalStateException("Unable to decode visibility " + entry.getKey(), e);
+                }
+            }
+            // @formatter::off
+            return fields.values().stream().map(Map::values).flatMap(Collection::stream).collect(Collectors.toCollection(LinkedList::new));
+            // @formatter::on
+        }
+        
+        private void transformEntry(Map.Entry<Key,Value> currEntry) throws IOException, MarkingFunctions.Exception {
+            SortedMap<Key,Value> rowEntries = WholeRowIterator.decodeRow(currEntry.getKey(), currEntry.getValue());
+            
+            for (Map.Entry<Key,Value> entry : rowEntries.entrySet()) {
+                setCurrentVars(entry);
+                
+                // If this row is a hidden event, do not continue transforming it and ensure any
+                // previously transformed entries for this row are not in the final results.
+                if (isColumnFamly(ColumnFamilyConstants.COLF_H)) {
+                    currField = null;
+                    fields.remove(currRow.toString());
+                    break;
+                }
+                
+                // Verify that the row should not be filtered out due to its datatype.
+                String dataType = getDataType();
+                if (hasAllowedDataType(dataType)) {
+                    
+                    // Set the current transformed field that will be modified from here on.
+                    setCurrentField(dataType);
+                    
+                    // If this an event field, then this is not an indexed field. Use the field name and timestamp of this entry.
+                    if (isColumnFamly(ColumnFamilyConstants.COLF_E)) {
+                        currField.setIndexOnly(false);
+                        setFieldNameAndAlias();
+                        setLastUpdated();
+                        // Check if this is a forward-indexed field.
+                    } else if (isColumnFamly(ColumnFamilyConstants.COLF_I)) {
+                        currField.setForwardIndexed(true);
+                        // Check if this is a reversed-indexed field
+                    } else if (isColumnFamly(ColumnFamilyConstants.COLF_RI)) {
+                        currField.setReverseIndexed(true);
+                        // If this is an description entry, extract the description and add it to the transformed field.
+                    } else if (isColumnFamly(ColumnFamilyConstants.COLF_DESC)) {
+                        setDescriptions();
+                        // If this is a type entry, add it to the field.
+                    } else if (isColumnFamly(ColumnFamilyConstants.COLF_T)) {
+                        setType();
+                        // Check if the field is tokenized.
+                    } else if (isColumnFamly(ColumnFamilyConstants.COLF_TF)) {
+                        currField.setTokenized(true);
+                    } else {
+                        log.warn("Unknown entry with key={}, value={}", currKey, currValue);
+                    }
+                    
+                    // If the field name is null, this is potentially an index-only field which has no event ("e") entry.
+                    // Use the field name of this entry. These values will be replaced if an event entry is encountered later on.
+                    if (currField.getFieldName() == null) {
+                        setFieldNameAndAlias();
+                    }
+                    
+                    // Determine the lastUpdated value for index-only fields without including timestamps from description rows.
+                    if (currField.isIndexOnly() && currField.getLastUpdated() == null && !isColumnFamly(ColumnFamilyConstants.COLF_DESC)) {
+                        setLastUpdated();
+                    }
+                }
+            }
+        }
+        
+        /**
+         * Set the current variables from the specified entry.
+         */
+        private void setCurrentVars(Map.Entry<Key,Value> entry) {
+            currKey = entry.getKey();
+            currValue = entry.getValue();
+            currKey.getRow(currRow);
+            currKey.getColumnFamily(currColumnFamily);
+            currColumnQualifier = currKey.getColumnQualifier().toString();
+        }
+        
+        /**
+         * Return true if the current column family is equal to the specified text, or false otherwise.
+         */
+        private boolean isColumnFamly(Text columnFamily) {
+            return columnFamily.equals(currColumnFamily);
+        }
+        
+        /**
+         * Return true if all data types are allowed or if the given data type is in the set of data type filters, or false otherwise.
+         */
+        private boolean hasAllowedDataType(String dataType) {
+            return acceptAllDataTypes || dataTypeFilters.contains(dataType);
+        }
+        
+        /**
+         * Return the data type from the current column qualifier.
+         */
+        private String getDataType() {
+            int nullPos = currColumnQualifier.indexOf('\0');
+            return (nullPos < 0) ? currColumnQualifier : currColumnQualifier.substring(0, nullPos);
+        }
+        
+        /**
+         * Set the current {@link DefaultMetadataField}. If a field already exists for the given field name and data type combination, it will be reused,
+         * otherwise a new {@link DefaultMetadataField} will be created.
+         */
+        private void setCurrentField(final String dataType) {
+            Map<String,DefaultMetadataField> dataTypes = fields.computeIfAbsent(currRow.toString(), k -> Maps.newHashMap());
+            currField = dataTypes.get(dataType);
+            
+            // If a field does not yet exist for the field name and data type, create a new one that
+            // defaults to index-only, which shall be cleared if we see an event entry.
+            if (currField == null) {
+                currField = new DefaultMetadataField();
+                currField.setIndexOnly(true);
+                currField.setDataType(dataType);
+                dataTypes.put(dataType, currField);
+            }
+        }
+        
+        /**
+         * Set the field name for the current {@link DefaultMetadataField}. If an alias exists for the field name, the alias will be used as the primary field
+         * name while the original field name is relegated to the internal field name.
+         */
+        private void setFieldNameAndAlias() {
+            String fieldName = currKey.getRow().toString();
+            if (aliases.containsKey(fieldName)) {
+                currField.setFieldName(aliases.get(fieldName));
+                currField.setInternalFieldName(fieldName);
+            } else {
+                currField.setFieldName(fieldName);
+            }
+        }
+        
+        /**
+         * Extract the description from the current value and add it to the current {@link DefaultMetadataField}.
+         */
+        private void setDescriptions() throws MarkingFunctions.Exception {
+            DefaultDescription description = responseObjectFactory.getDescription();
+            description.setDescription(currValue.toString());
+            description.setMarkings(markingFunctions.translateFromColumnVisibility(currKey.getColumnVisibilityParsed()));
+            currField.getDescriptions().add(description);
+        }
+        
+        /**
+         * Set the normalized type for the current {@link DefaultMetadataField}. If no normalized version can be found for the type, the type will default to
+         * "Unknown".
+         */
+        private void setType() {
+            int nullPos = currColumnQualifier.indexOf('\0');
+            String type = currColumnQualifier.substring(nullPos + 1);
+            String normalizedType = normalizationMap.get(type);
+            currField.addType(normalizedType != null ? normalizedType : "Unknown");
+        }
+        
+        /**
+         * Set the last updated date for the current {@link DefaultMetadataField} based on the timestamp of the current entry.
+         */
+        private void setLastUpdated() {
+            currField.setLastUpdated(DATE_FORMATTER.print(currKey.getTimestamp()));
+        }
+    }
+}

--- a/service/src/main/java/datawave/microservice/metadata/DefaultMetadataFieldScanner.java
+++ b/service/src/main/java/datawave/microservice/metadata/DefaultMetadataFieldScanner.java
@@ -68,6 +68,7 @@ public class DefaultMetadataFieldScanner {
      * Create and return a scanner that will aggregate metadata entries by their row.
      * 
      * @return the scanner
+     * @throws TableNotFoundException if the metadata table is not found
      */
     private BatchScanner createScanner() throws TableNotFoundException {
         BatchScanner scanner = ScannerHelper.createBatchScanner(connectionConfig.getConnector(), connectionConfig.getMetadataTable(),
@@ -198,9 +199,7 @@ public class DefaultMetadataFieldScanner {
             }
         }
         
-        /**
-         * Set the current variables from the specified entry.
-         */
+        // Set the current variables from the specified entry.
         private void setCurrentVars(Map.Entry<Key,Value> entry) {
             currKey = entry.getKey();
             currValue = entry.getValue();
@@ -209,32 +208,24 @@ public class DefaultMetadataFieldScanner {
             currColumnQualifier = currKey.getColumnQualifier().toString();
         }
         
-        /**
-         * Return true if the current column family is equal to the specified text, or false otherwise.
-         */
+        // Return true if the current column family is equal to the specified text, or false otherwise.
         private boolean isColumnFamly(Text columnFamily) {
             return columnFamily.equals(currColumnFamily);
         }
         
-        /**
-         * Return true if all data types are allowed or if the given data type is in the set of data type filters, or false otherwise.
-         */
+        // Return true if all data types are allowed or if the given data type is in the set of data type filters, or false otherwise.
         private boolean hasAllowedDataType(String dataType) {
             return acceptAllDataTypes || dataTypeFilters.contains(dataType);
         }
         
-        /**
-         * Return the data type from the current column qualifier.
-         */
+        // Return the data type from the current column qualifier.
         private String getDataType() {
             int nullPos = currColumnQualifier.indexOf('\0');
             return (nullPos < 0) ? currColumnQualifier : currColumnQualifier.substring(0, nullPos);
         }
         
-        /**
-         * Set the current {@link DefaultMetadataField}. If a field already exists for the given field name and data type combination, it will be reused,
-         * otherwise a new {@link DefaultMetadataField} will be created.
-         */
+        //Set the current {@link DefaultMetadataField}. If a field already exists for the given field name and data type combination, it will be reused,
+        //  otherwise a new {@link DefaultMetadataField} will be created.
         private void setCurrentField(final String dataType) {
             Map<String,DefaultMetadataField> dataTypes = fields.computeIfAbsent(currRow.toString(), k -> Maps.newHashMap());
             currField = dataTypes.get(dataType);
@@ -249,10 +240,8 @@ public class DefaultMetadataFieldScanner {
             }
         }
         
-        /**
-         * Set the field name for the current {@link DefaultMetadataField}. If an alias exists for the field name, the alias will be used as the primary field
-         * name while the original field name is relegated to the internal field name.
-         */
+        // Set the field name for the current {@link DefaultMetadataField}. If an alias exists for the field name, the alias will be used as the primary field
+        // name while the original field name is relegated to the internal field name.
         private void setFieldNameAndAlias() {
             String fieldName = currKey.getRow().toString();
             if (aliases.containsKey(fieldName)) {
@@ -263,9 +252,7 @@ public class DefaultMetadataFieldScanner {
             }
         }
         
-        /**
-         * Extract the description from the current value and add it to the current {@link DefaultMetadataField}.
-         */
+        // Extract the description from the current value and add it to the current {@link DefaultMetadataField}.
         private void setDescriptions() throws MarkingFunctions.Exception {
             DefaultDescription description = responseObjectFactory.getDescription();
             description.setDescription(currValue.toString());
@@ -273,10 +260,8 @@ public class DefaultMetadataFieldScanner {
             currField.getDescriptions().add(description);
         }
         
-        /**
-         * Set the normalized type for the current {@link DefaultMetadataField}. If no normalized version can be found for the type, the type will default to
-         * "Unknown".
-         */
+        // Set the normalized type for the current {@link DefaultMetadataField}. If no normalized version can be found for the type, the type will default to
+        // "Unknown".
         private void setType() {
             int nullPos = currColumnQualifier.indexOf('\0');
             String type = currColumnQualifier.substring(nullPos + 1);
@@ -284,9 +269,7 @@ public class DefaultMetadataFieldScanner {
             currField.addType(normalizedType != null ? normalizedType : "Unknown");
         }
         
-        /**
-         * Set the last updated date for the current {@link DefaultMetadataField} based on the timestamp of the current entry.
-         */
+        // Set the last updated date for the current {@link DefaultMetadataField} based on the timestamp of the current entry.
         private void setLastUpdated() {
             currField.setLastUpdated(DATE_FORMATTER.print(currKey.getTimestamp()));
         }

--- a/service/src/main/java/datawave/microservice/metadata/DefaultMetadataFieldScanner.java
+++ b/service/src/main/java/datawave/microservice/metadata/DefaultMetadataFieldScanner.java
@@ -68,7 +68,8 @@ public class DefaultMetadataFieldScanner {
      * Create and return a scanner that will aggregate metadata entries by their row.
      * 
      * @return the scanner
-     * @throws TableNotFoundException if the metadata table is not found
+     * @throws TableNotFoundException
+     *             if the metadata table is not found
      */
     private BatchScanner createScanner() throws TableNotFoundException {
         BatchScanner scanner = ScannerHelper.createBatchScanner(connectionConfig.getConnector(), connectionConfig.getMetadataTable(),
@@ -224,8 +225,8 @@ public class DefaultMetadataFieldScanner {
             return (nullPos < 0) ? currColumnQualifier : currColumnQualifier.substring(0, nullPos);
         }
         
-        //Set the current {@link DefaultMetadataField}. If a field already exists for the given field name and data type combination, it will be reused,
-        //  otherwise a new {@link DefaultMetadataField} will be created.
+        // Set the current {@link DefaultMetadataField}. If a field already exists for the given field name and data type combination, it will be reused,
+        // otherwise a new {@link DefaultMetadataField} will be created.
         private void setCurrentField(final String dataType) {
             Map<String,DefaultMetadataField> dataTypes = fields.computeIfAbsent(currRow.toString(), k -> Maps.newHashMap());
             currField = dataTypes.get(dataType);

--- a/service/src/test/java/datawave/microservice/dictionary/DataDictionaryOperationsTest.java
+++ b/service/src/test/java/datawave/microservice/dictionary/DataDictionaryOperationsTest.java
@@ -113,6 +113,7 @@ public class DataDictionaryOperationsTest {
         // @formatter:on
         
         ResponseEntity<DefaultDataDictionary> response = jwtRestTemplate.exchange(adminUser, HttpMethod.GET, uri, DefaultDataDictionary.class);
+        System.out.println(response.toString());
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
     

--- a/service/src/test/java/datawave/microservice/dictionary/DataDictionaryOperationsTest.java
+++ b/service/src/test/java/datawave/microservice/dictionary/DataDictionaryOperationsTest.java
@@ -113,7 +113,6 @@ public class DataDictionaryOperationsTest {
         // @formatter:on
         
         ResponseEntity<DefaultDataDictionary> response = jwtRestTemplate.exchange(adminUser, HttpMethod.GET, uri, DefaultDataDictionary.class);
-        System.out.println(response.toString());
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
     

--- a/service/src/test/java/datawave/microservice/dictionary/data/DatawaveDataDictionaryImplTest.java
+++ b/service/src/test/java/datawave/microservice/dictionary/data/DatawaveDataDictionaryImplTest.java
@@ -97,7 +97,7 @@ public class DatawaveDataDictionaryImplTest {
         givenInitializedMetadataDescriptionsHelper();
         
         // Execute function under test.
-        dataDictionary.addDescription(connectionConfig, FIELD_NAME, DATATYPE, description);
+        dataDictionary.setDescription(connectionConfig, FIELD_NAME, DATATYPE, description);
         
         // Verify expected calls.
         Set<DefaultDescription> descriptions = Collections.singleton(description);
@@ -126,7 +126,7 @@ public class DatawaveDataDictionaryImplTest {
         givenInitializedMetadataDescriptionsHelper();
         
         // Execute function under test.
-        dataDictionary.addDescription(connectionConfig, dictionaryField);
+        dataDictionary.setDescription(connectionConfig, dictionaryField);
         
         // Verify expected calls.
         verify(metadataDescriptionsHelper).initialize(connector, METADATA_TABLE, AUTHS);
@@ -149,7 +149,7 @@ public class DatawaveDataDictionaryImplTest {
         givenInitializedMetadataDescriptionsHelper();
         
         // Execute function under test.
-        dataDictionary.addDescriptions(connectionConfig, FIELD_NAME, DATATYPE, descriptions);
+        dataDictionary.setDescriptions(connectionConfig, FIELD_NAME, DATATYPE, descriptions);
         
         // Verify expected calls.
         verify(metadataDescriptionsHelper).initialize(connector, METADATA_TABLE, AUTHS);
@@ -172,7 +172,7 @@ public class DatawaveDataDictionaryImplTest {
         givenInitializedMetadataDescriptionsHelper();
         
         // Execute function under test.
-        dataDictionary.addDescriptions(connectionConfig, FIELD_NAME, DATATYPE, descriptions);
+        dataDictionary.setDescriptions(connectionConfig, FIELD_NAME, DATATYPE, descriptions);
         
         // Verify expected calls.
         verify(metadataDescriptionsHelper).initialize(connector, METADATA_TABLE, AUTHS);

--- a/service/src/test/java/datawave/microservice/metadata/DefaultMetadataFieldScannerTest.java
+++ b/service/src/test/java/datawave/microservice/metadata/DefaultMetadataFieldScannerTest.java
@@ -1,0 +1,228 @@
+package datawave.microservice.metadata;
+
+import datawave.accumulo.inmemory.InMemoryInstance;
+import datawave.data.ColumnFamilyConstants;
+import datawave.marking.MarkingFunctions;
+import datawave.microservice.dictionary.config.ResponseObjectFactory;
+import datawave.microservice.dictionary.data.ConnectionConfig;
+import datawave.webservice.query.result.metadata.DefaultMetadataField;
+import datawave.webservice.results.datadictionary.DefaultDataDictionary;
+import datawave.webservice.results.datadictionary.DefaultDescription;
+import datawave.webservice.results.datadictionary.DefaultDictionaryField;
+import datawave.webservice.results.datadictionary.DefaultFields;
+import org.apache.accumulo.core.client.BatchWriter;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.data.Mutation;
+import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.hadoop.io.Text;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(JUnit4.class)
+public class DefaultMetadataFieldScannerTest {
+    
+    private static final String DATE = "20200115051230";
+    private static final long TIMESTAMP = ZonedDateTime.of(LocalDateTime.of(2020, 1, 15, 5, 12, 30), ZoneId.systemDefault()).toInstant().toEpochMilli();
+    private static final String MODEL_TABLE = "modelTable";
+    private static final String METADATA_TABLE = "metadataTable";
+    private static final String[] AUTH = {"PRIVATE"};
+    private static final Set<Authorizations> AUTHS = Collections.singleton(new Authorizations(AUTH));
+    
+    private static final ResponseObjectFactory<DefaultDescription,DefaultDataDictionary,DefaultMetadataField,DefaultDictionaryField,DefaultFields> RESPONSE_OBJECT_FACTORY = new ResponseObjectFactory<DefaultDescription,DefaultDataDictionary,DefaultMetadataField,DefaultDictionaryField,DefaultFields>() {
+        @Override
+        public DefaultDataDictionary getDataDictionary() {
+            return null;
+        }
+        
+        @Override
+        public DefaultDescription getDescription() {
+            return new DefaultDescription();
+        }
+        
+        @Override
+        public DefaultFields getFields() {
+            return new DefaultFields();
+        }
+    };
+    
+    private Connector connector;
+    
+    private DefaultMetadataFieldScanner scanner;
+    
+    @Before
+    public void setUp() throws Exception {
+        InMemoryInstance instance = new InMemoryInstance();
+        connector = instance.getConnector("root", new PasswordToken(""));
+        connector.securityOperations().changeUserAuthorizations("root", new Authorizations(AUTH));
+        connector.tableOperations().create(METADATA_TABLE);
+        connector.tableOperations().create(MODEL_TABLE);
+        populateMetadataTable();
+        
+        Map<String,String> normalizerMapping = new HashMap<>();
+        normalizerMapping.put("datawave.data.type.LcNoDiacriticsType", "Text");
+        normalizerMapping.put("datawave.data.type.NumberType", "Number");
+        
+        ConnectionConfig connectionConfig = new ConnectionConfig();
+        connectionConfig.setConnector(connector);
+        connectionConfig.setMetadataTable(METADATA_TABLE);
+        connectionConfig.setAuths(AUTHS);
+        
+        scanner = new DefaultMetadataFieldScanner(new MarkingFunctions.Default(), RESPONSE_OBJECT_FACTORY, normalizerMapping, connectionConfig, 1);
+    }
+    
+    @Test
+    public void whenRetrievingFields_givenNoDataTypeFilters_shouldReturnUnfilteredResults() throws TableNotFoundException {
+        DefaultMetadataField barField = new DefaultMetadataField();
+        barField.setFieldName("BAR_FIELD");
+        barField.setDataType("csv");
+        barField.setForwardIndexed(true);
+        barField.setReverseIndexed(true);
+        barField.setTokenized(true);
+        barField.setTypes(Collections.singletonList("Text"));
+        barField.setDescription(Collections.singleton(createDescription("Barfield Description")));
+        barField.setLastUpdated(DATE);
+        
+        DefaultMetadataField contributorId = new DefaultMetadataField();
+        contributorId.setFieldName("CONTRIBUTOR_ID");
+        contributorId.setDataType("enwiki");
+        contributorId.setForwardIndexed(true);
+        contributorId.setTypes(Collections.singletonList("Number"));
+        contributorId.setDescription(Collections.singleton(createDescription("ContributorId Description")));
+        contributorId.setLastUpdated(DATE);
+        
+        DefaultMetadataField name = new DefaultMetadataField();
+        name.setFieldName("NAME");
+        name.setDataType("tvmaze");
+        name.setForwardIndexed(true);
+        name.setReverseIndexed(true);
+        name.setTypes(Collections.singletonList("Unknown"));
+        name.setLastUpdated(DATE);
+        
+        Collection<DefaultMetadataField> fields = scanner.getFields(Collections.emptyMap(), Collections.emptySet());
+        assertThat(fields).containsExactlyInAnyOrder(barField, contributorId, name);
+    }
+    
+    @Test
+    public void whenRetrievingFields_givenDataTypeFilters_shouldReturnFilteredResults() throws TableNotFoundException {
+        DefaultMetadataField barField = new DefaultMetadataField();
+        barField.setFieldName("BAR_FIELD");
+        barField.setDataType("csv");
+        barField.setForwardIndexed(true);
+        barField.setReverseIndexed(true);
+        barField.setTokenized(true);
+        barField.setTypes(Collections.singletonList("Text"));
+        barField.setDescription(Collections.singleton(createDescription("Barfield Description")));
+        barField.setLastUpdated(DATE);
+        
+        DefaultMetadataField contributorId = new DefaultMetadataField();
+        contributorId.setFieldName("CONTRIBUTOR_ID");
+        contributorId.setDataType("enwiki");
+        contributorId.setForwardIndexed(true);
+        contributorId.setTypes(Collections.singletonList("Number"));
+        contributorId.setDescription(Collections.singleton(createDescription("ContributorId Description")));
+        contributorId.setLastUpdated(DATE);
+        
+        Set<String> dataTypeFilters = new HashSet<>();
+        dataTypeFilters.add("csv");
+        dataTypeFilters.add("enwiki");
+        Collection<DefaultMetadataField> fields = scanner.getFields(Collections.emptyMap(), dataTypeFilters);
+        assertThat(fields).containsExactlyInAnyOrder(barField, contributorId);
+    }
+    
+    @Test
+    public void whenRetrievingFields_givenAliases_shouldReturnResultsWithAliases() throws TableNotFoundException {
+        DefaultMetadataField barField = new DefaultMetadataField();
+        barField.setFieldName("bar_field_alias");
+        barField.setInternalFieldName("BAR_FIELD");
+        barField.setDataType("csv");
+        barField.setForwardIndexed(true);
+        barField.setReverseIndexed(true);
+        barField.setTokenized(true);
+        barField.setTypes(Collections.singletonList("Text"));
+        barField.setDescription(Collections.singleton(createDescription("Barfield Description")));
+        barField.setLastUpdated(DATE);
+        
+        DefaultMetadataField contributorId = new DefaultMetadataField();
+        contributorId.setFieldName("contributor_id_alias");
+        contributorId.setInternalFieldName("CONTRIBUTOR_ID");
+        contributorId.setDataType("enwiki");
+        contributorId.setForwardIndexed(true);
+        contributorId.setTypes(Collections.singletonList("Number"));
+        contributorId.setDescription(Collections.singleton(createDescription("ContributorId Description")));
+        contributorId.setLastUpdated(DATE);
+        
+        DefaultMetadataField name = new DefaultMetadataField();
+        name.setFieldName("NAME");
+        name.setDataType("tvmaze");
+        name.setForwardIndexed(true);
+        name.setReverseIndexed(true);
+        name.setTypes(Collections.singletonList("Unknown"));
+        name.setLastUpdated(DATE);
+        
+        Map<String,String> aliases = new HashMap<>();
+        aliases.put("BAR_FIELD", "bar_field_alias");
+        aliases.put("CONTRIBUTOR_ID", "contributor_id_alias");
+        Collection<DefaultMetadataField> fields = scanner.getFields(aliases, Collections.emptySet());
+        assertThat(fields).containsExactlyInAnyOrder(barField, contributorId, name);
+    }
+    
+    private void populateMetadataTable() throws TableNotFoundException, MutationsRejectedException {
+        Mutation barField = new Mutation(new Text("BAR_FIELD"));
+        barField.put(new Text(ColumnFamilyConstants.COLF_E), new Text("csv"), TIMESTAMP, new Value());
+        barField.put(new Text(ColumnFamilyConstants.COLF_I), new Text("csv"), TIMESTAMP, new Value());
+        barField.put(new Text(ColumnFamilyConstants.COLF_RI), new Text("csv"), TIMESTAMP, new Value());
+        barField.put(new Text(ColumnFamilyConstants.COLF_TF), new Text("csv"), TIMESTAMP, new Value());
+        barField.put(new Text(ColumnFamilyConstants.COLF_T), new Text("csv\0datawave.data.type.LcNoDiacriticsType"), TIMESTAMP, new Value());
+        barField.put(new Text(ColumnFamilyConstants.COLF_DESC), new Text("csv"), new ColumnVisibility("PRIVATE"), TIMESTAMP, new Value("Barfield Description"));
+        
+        Mutation contributorId = new Mutation(new Text("CONTRIBUTOR_ID"));
+        contributorId.put(new Text(ColumnFamilyConstants.COLF_E), new Text("enwiki"), TIMESTAMP, new Value());
+        contributorId.put(new Text(ColumnFamilyConstants.COLF_I), new Text("enwiki"), TIMESTAMP, new Value());
+        contributorId.put(new Text(ColumnFamilyConstants.COLF_T), new Text("enwiki\0datawave.data.type.NumberType"), TIMESTAMP, new Value());
+        contributorId.put(new Text(ColumnFamilyConstants.COLF_DESC), new Text("enwiki"), new ColumnVisibility("PRIVATE"), TIMESTAMP,
+                        new Value("ContributorId Description"));
+        
+        Mutation name = new Mutation(new Text("NAME"));
+        name.put(new Text(ColumnFamilyConstants.COLF_E), new Text("tvmaze"), TIMESTAMP, new Value());
+        name.put(new Text(ColumnFamilyConstants.COLF_I), new Text("tvmaze"), TIMESTAMP, new Value());
+        name.put(new Text(ColumnFamilyConstants.COLF_RI), new Text("tvmaze"), TIMESTAMP, new Value());
+        name.put(new Text(ColumnFamilyConstants.COLF_T), new Text("tvmaze\0not.a.known.type"), TIMESTAMP, new Value());
+        
+        BatchWriter writer = connector.createBatchWriter(METADATA_TABLE, 10, 1024, 1);
+        writer.addMutation(barField);
+        writer.addMutation(contributorId);
+        writer.addMutation(name);
+        writer.flush();
+        writer.close();
+    }
+    
+    private DefaultDescription createDescription(String descriptionText) {
+        DefaultDescription description = new DefaultDescription();
+        description.setDescription(descriptionText);
+        
+        Map<String,String> markings = new HashMap<>();
+        markings.put("columnVisibility", "PRIVATE}");
+        description.setMarkings(markings);
+        
+        return description;
+    }
+}


### PR DESCRIPTION
In order to fix issues for #706, additional parameters will need to be
implemented in the REST api. These will come with their own changes that
may be significant.

Perform an initial refactor of the data dictionary service with the
following goals:
- Reduce method signature size between DataDictionaryOperations and
DataDictionary with ConnectionConfig class.
- Extract DefaultMetadataField transformation to separate class to
improve code clarity and make testing easier.
- Reduce duplicated code where possible.
- Add more unit tests and documentation.