### PR TITLE
Dictionary Service to generate HTML via Spring MVC, Data Dictionary page Enhancements

### DIFF
--- a/api/src/main/java/datawave/webservice/dictionary/data/DataDictionaryBase.java
+++ b/api/src/main/java/datawave/webservice/dictionary/data/DataDictionaryBase.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
 
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlSeeAlso(DefaultDataDictionary.class)
-public abstract class DataDictionaryBase<T,M extends MetadataFieldBase> extends BaseResponse implements TotalResultsAware, Message<T>, HtmlProvider {
+public abstract class DataDictionaryBase<T,M extends MetadataFieldBase> extends BaseResponse implements TotalResultsAware, Message<T> {
     
     public abstract List<M> getFields();
     
@@ -25,13 +25,9 @@ public abstract class DataDictionaryBase<T,M extends MetadataFieldBase> extends 
     
     public abstract long getTotalResults();
     
-    public abstract String getTitle();
+    public abstract String getJqueryUri();
     
-    public abstract String getHeadContent();
-    
-    public abstract String getPageHeader();
-    
-    public abstract String getMainContent();
+    public abstract String getDatatablesUri();
     
     public abstract void transformFields(final Consumer<M> transformer);
 }

--- a/api/src/main/java/datawave/webservice/dictionary/data/DataDictionaryBase.java
+++ b/api/src/main/java/datawave/webservice/dictionary/data/DataDictionaryBase.java
@@ -1,6 +1,5 @@
 package datawave.webservice.dictionary.data;
 
-import datawave.webservice.HtmlProvider;
 import datawave.webservice.metadata.MetadataFieldBase;
 import datawave.webservice.result.BaseResponse;
 import datawave.webservice.result.TotalResultsAware;

--- a/api/src/main/java/datawave/webservice/dictionary/data/DataDictionaryBase.java
+++ b/api/src/main/java/datawave/webservice/dictionary/data/DataDictionaryBase.java
@@ -24,9 +24,5 @@ public abstract class DataDictionaryBase<T,M extends MetadataFieldBase> extends 
     
     public abstract long getTotalResults();
     
-    public abstract String getJqueryUri();
-    
-    public abstract String getDatatablesUri();
-    
     public abstract void transformFields(final Consumer<M> transformer);
 }

--- a/api/src/main/java/datawave/webservice/dictionary/data/DefaultDataDictionary.java
+++ b/api/src/main/java/datawave/webservice/dictionary/data/DefaultDataDictionary.java
@@ -30,8 +30,6 @@ public class DefaultDataDictionary extends DataDictionaryBase<DefaultDataDiction
                 implements TotalResultsAware, Message<DefaultDataDictionary> {
     
     private static final long serialVersionUID = 1L;
-    private final String jqueryUri;
-    private final String datatablesUri;
     
     @XmlElementWrapper(name = "MetadataFields")
     @XmlElement(name = "MetadataField")
@@ -40,14 +38,7 @@ public class DefaultDataDictionary extends DataDictionaryBase<DefaultDataDiction
     @XmlElement(name = "TotalResults")
     private Long totalResults = null;
     
-    public DefaultDataDictionary() {
-        this("/webjars/jquery/", "/webjars/datatables/");
-    }
-    
-    public DefaultDataDictionary(String jqueryUri, String datatablesUri) {
-        this.jqueryUri = jqueryUri;
-        this.datatablesUri = datatablesUri;
-    }
+    public DefaultDataDictionary() {}
     
     public DefaultDataDictionary(Collection<DefaultMetadataField> fields) {
         this();
@@ -59,14 +50,6 @@ public class DefaultDataDictionary extends DataDictionaryBase<DefaultDataDiction
             setTotalResults(this.fields.size());
             this.setHasResults(true);
         }
-    }
-    
-    public String getJqueryUri() {
-        return jqueryUri;
-    }
-    
-    public String getDatatablesUri() {
-        return datatablesUri;
     }
     
     public List<DefaultMetadataField> getFields() {

--- a/api/src/main/java/datawave/webservice/dictionary/data/DefaultFields.java
+++ b/api/src/main/java/datawave/webservice/dictionary/data/DefaultFields.java
@@ -2,7 +2,6 @@ package datawave.webservice.dictionary.data;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
-import datawave.webservice.HtmlProvider;
 import datawave.webservice.result.TotalResultsAware;
 import io.protostuff.Input;
 import io.protostuff.Message;
@@ -21,8 +20,7 @@ import java.util.Map.Entry;
 
 @XmlRootElement(name = "DefaultFieldsResponse")
 @XmlAccessorType(XmlAccessType.NONE)
-public class DefaultFields extends FieldsBase<DefaultFields,DefaultDictionaryField,DefaultDescription>
-                implements TotalResultsAware, Message<DefaultFields>, HtmlProvider {
+public class DefaultFields extends FieldsBase<DefaultFields,DefaultDictionaryField,DefaultDescription> implements TotalResultsAware, Message<DefaultFields> {
     
     private static final long serialVersionUID = 1L;
     private static final String TITLE = "Field Descriptions", EMPTY = "";
@@ -175,53 +173,4 @@ public class DefaultFields extends FieldsBase<DefaultFields,DefaultDictionaryFie
             fieldMap.put("descriptions", 2);
         }
     };
-    
-    @Override
-    public String getTitle() {
-        return TITLE;
-    }
-    
-    @Override
-    public String getPageHeader() {
-        return getTitle();
-    }
-    
-    @Override
-    public String getHeadContent() {
-        return EMPTY;
-    }
-    
-    @Override
-    public String getMainContent() {
-        StringBuilder builder = new StringBuilder();
-        
-        builder.append("<table>\n");
-        builder.append("<tr><th>Datatype</th><th>FieldName</th><th>Description</th></tr>");
-        
-        int x = 0;
-        for (DefaultDictionaryField field : this.getFields()) {
-            for (DefaultDescription desc : field.getDescriptions()) {
-                addDescriptionRow(field, desc, x, builder);
-                x++;
-            }
-        }
-        
-        builder.append("</table>\n");
-        
-        return builder.toString();
-    }
-    
-    public static void addDescriptionRow(DictionaryFieldBase<?,? extends DescriptionBase> field, DescriptionBase desc, int rowNum, StringBuilder builder) {
-        // highlight alternating rows
-        if (rowNum % 2 == 0) {
-            builder.append("<tr class=\"highlight\">");
-        } else {
-            builder.append("<tr>");
-        }
-        
-        builder.append("<td>").append(field.getDatatype()).append("</td>");
-        builder.append("<td>").append(field.getFieldName()).append("</td>");
-        builder.append("<td>").append(desc.getDescription()).append("</td>");
-        builder.append("</tr>");
-    }
 }

--- a/api/src/main/java/datawave/webservice/dictionary/edge/DefaultEdgeDictionary.java
+++ b/api/src/main/java/datawave/webservice/dictionary/edge/DefaultEdgeDictionary.java
@@ -1,6 +1,5 @@
 package datawave.webservice.dictionary.edge;
 
-import datawave.webservice.HtmlProvider;
 import datawave.webservice.query.result.util.protostuff.FieldAccessor;
 import datawave.webservice.query.result.util.protostuff.ProtostuffField;
 import datawave.webservice.result.TotalResultsAware;
@@ -28,10 +27,9 @@ import java.util.List;
 @XmlAccessorType(XmlAccessType.NONE)
 @XmlAccessorOrder(XmlAccessOrder.ALPHABETICAL)
 public class DefaultEdgeDictionary extends EdgeDictionaryBase<DefaultEdgeDictionary,DefaultMetadata>
-                implements TotalResultsAware, Message<DefaultEdgeDictionary>, HtmlProvider {
+                implements TotalResultsAware, Message<DefaultEdgeDictionary> {
     
     private static final long serialVersionUID = 1L;
-    private static final String TITLE = "Edge Dictionary", SEP = ", ";
     
     @XmlElementWrapper(name = "EdgeMetadata")
     @XmlElement(name = "Metadata")
@@ -167,70 +165,5 @@ public class DefaultEdgeDictionary extends EdgeDictionaryBase<DefaultEdgeDiction
     @Override
     public long getTotalResults() {
         return this.totalResults;
-    }
-    
-    @Override
-    public String getTitle() {
-        return TITLE;
-    }
-    
-    @Override
-    public String getHeadContent() {
-        return "";
-    }
-    
-    public String getPageHeader() {
-        return getTitle();
-    }
-    
-    @Override
-    public String getMainContent() {
-        StringBuilder builder = new StringBuilder(2048);
-        builder.append("<div><ul>").append("<li class=\"left\">Edge Type: Defined either by Datawave Configuration files or Edge enrichment field.</li>")
-                        .append("<li class=\"left\">Edge Relationship: Defined by Datawave Configuration files</li>")
-                        .append("<li class=\"left\">Edge Attribute1 Source: Defined by Datawave Configuration files and optional attributes Attribute2 and Attribute3</li>")
-                        .append("<li class=\"left\">Fields: List of Field Name pairs used to generate this edge type.</li>")
-                        .append("<li class=\"left\">Fields Format:<pre>[Source Field, Target Field | Enrichment Field=Enrichment Field Value]</pre></li>")
-                        .append("<li class=\"left\">Date: start date of edge type creation, format: yyyyMMdd</li>").append("</ul></div>");
-        
-        builder.append("<table id=\"myTable\" class=\"creds\">\n")
-                        .append("<thead><tr><th>Edge Type</th><th>Edge Relationship</th><th>Edge Attribute1 Source</th>")
-                        .append("<th>Fields</th><th>Date</th></tr></thead>");
-        
-        builder.append("<tbody>");
-        int x = 0;
-        for (MetadataBase<DefaultMetadata> metadata : this.getMetadataList()) {
-            // highlight alternating rows
-            if (x % 2 == 0) {
-                builder.append("<tr class=\"highlight\">");
-            } else {
-                builder.append("<tr>");
-            }
-            x++;
-            
-            String type = metadata.getEdgeType();
-            String relationship = metadata.getEdgeRelationship();
-            String collect = metadata.getEdgeAttribute1Source();
-            StringBuilder fieldBuilder = new StringBuilder();
-            for (EventField field : metadata.getEventFields()) {
-                fieldBuilder.append(field).append(SEP);
-            }
-            
-            String fieldNames = fieldBuilder.toString().substring(0, fieldBuilder.length() - 2);
-            String date = metadata.getStartDate();
-            
-            builder.append("<td>").append(type).append("</td>");
-            builder.append("<td>").append(relationship).append("</td>");
-            builder.append("<td>").append(collect).append("</td>");
-            builder.append("<td>").append(fieldNames).append("</td>");
-            builder.append("<td>").append(date).append("</td>");
-            
-            builder.append("</td>").append("</tr>");
-        }
-        builder.append("</tbody>");
-        
-        builder.append("</table>\n");
-        
-        return builder.toString();
     }
 }

--- a/api/src/main/java/datawave/webservice/dictionary/edge/EdgeDictionaryBase.java
+++ b/api/src/main/java/datawave/webservice/dictionary/edge/EdgeDictionaryBase.java
@@ -20,12 +20,4 @@ public abstract class EdgeDictionaryBase<T,F extends MetadataBase<F>> extends Ba
     
     public abstract long getTotalResults();
     
-    public abstract String getTitle();
-    
-    public abstract String getHeadContent();
-    
-    public abstract String getPageHeader();
-    
-    public abstract String getMainContent();
-    
 }

--- a/api/src/main/java/datawave/webservice/model/Model.java
+++ b/api/src/main/java/datawave/webservice/model/Model.java
@@ -1,6 +1,5 @@
 package datawave.webservice.model;
 
-import datawave.webservice.HtmlProvider;
 import datawave.webservice.result.BaseResponse;
 import lombok.Data;
 
@@ -11,30 +10,15 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
-import java.text.MessageFormat;
 import java.util.TreeSet;
 
 @Data
 @XmlRootElement(name = "Model")
 @XmlAccessorType(XmlAccessType.NONE)
-public class Model extends BaseResponse implements Serializable, HtmlProvider {
+public class Model extends BaseResponse implements Serializable {
     
     private static final long serialVersionUID = 1L;
-    private String jqueryUri;
-    private String dataTablesUri;
-    private static final String TITLE = "Model Description", EMPTY = "";
-    private static final String DATA_TABLES_TEMPLATE = "<script type=''text/javascript'' src=''{0}''></script>\n"
-                    + "<script type=''text/javascript'' src=''{1}''></script>\n" + "<script type=''text/javascript''>\n"
-                    + "$(document).ready(function() '{' $(''#myTable'').dataTable('{'\"bPaginate\": false, \"aaSorting\": [[3, \"asc\"]], \"bStateSave\": true'}') '}')\n"
-                    + "</script>\n";
     
-    public Model(String jqueryUri, String datatablesUri) {
-        this.jqueryUri = jqueryUri;
-        this.dataTablesUri = datatablesUri;
-        
-    }
-    
-    // Only used in ModelBeanTest now
     public Model() {};
     
     @XmlAttribute(name = "name", required = true)
@@ -43,69 +27,4 @@ public class Model extends BaseResponse implements Serializable, HtmlProvider {
     @XmlElementWrapper(name = "Mappings")
     @XmlElement(name = "Mapping")
     private TreeSet<FieldMapping> fields = new TreeSet<FieldMapping>();
-    
-    /*
-     * (non-Javadoc)
-     * 
-     * @see datawave.webservice.HtmlProvider#getTitle()
-     */
-    @Override
-    public String getTitle() {
-        return TITLE;
-    }
-    
-    /*
-     * (non-Javadoc)
-     * 
-     * @see datawave.webservice.HtmlProvider#getPageHeader()
-     */
-    @Override
-    public String getPageHeader() {
-        return TITLE;
-    }
-    
-    /*
-     * (non-Javadoc)
-     * 
-     * @see datawave.webservice.HtmlProvider#getHeadContent()
-     */
-    @Override
-    public String getHeadContent() {
-        return MessageFormat.format(DATA_TABLES_TEMPLATE, jqueryUri, dataTablesUri);
-    }
-    
-    /*
-     * (non-Javadoc)
-     * 
-     * @see datawave.webservice.HtmlProvider#getMainContent()
-     */
-    @Override
-    public String getMainContent() {
-        StringBuilder builder = new StringBuilder();
-        
-        builder.append("<div>\n");
-        builder.append("<div id=\"myTable_wrapper\" class=\"dataTables_wrapper no-footer\">\n");
-        builder.append("<table id=\"myTable\" class=\"dataTable no-footer\" role=\"grid\" aria-describedby=\"myTable_info\">\n");
-        
-        builder.append("<thead><tr><th>Visibility</th><th>FieldName</th><th>DataType</th><th>ModelFieldName</th><th>Direction</th></tr></thead>");
-        builder.append("<tbody>");
-        
-        for (FieldMapping f : this.getFields()) {
-            builder.append("<td>").append(f.getColumnVisibility()).append("</td>");
-            builder.append("<td>").append(f.getFieldName()).append("</td>");
-            builder.append("<td>").append(f.getDatatype()).append("</td>");
-            builder.append("<td>").append(f.getModelFieldName()).append("</td>");
-            builder.append("<td>").append(f.getDirection()).append("</td>");
-            builder.append("</tr>");
-        }
-        
-        builder.append("</tbody>");
-        builder.append("  </table>\n");
-        builder.append("  <div class=\"dataTables_info\" id=\"myTable_info\" role=\"status\" aria-live=\"polite\"></div>\n");
-        builder.append("</div>\n");
-        builder.append("</div>");
-        
-        return builder.toString();
-    }
-    
 }

--- a/api/src/main/java/datawave/webservice/model/ModelList.java
+++ b/api/src/main/java/datawave/webservice/model/ModelList.java
@@ -1,6 +1,5 @@
 package datawave.webservice.model;
 
-import datawave.webservice.HtmlProvider;
 import datawave.webservice.result.BaseResponse;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,97 +8,22 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
-import java.text.MessageFormat;
 import java.util.HashSet;
 
 @Data
 @NoArgsConstructor
 @XmlRootElement(name = "ModelList")
-public class ModelList extends BaseResponse implements Serializable, HtmlProvider {
+public class ModelList extends BaseResponse implements Serializable {
     
-    private String jqueryUri;
-    private String dataTablesUri;
     private String modelTableName;
     
     private static final long serialVersionUID = 1L;
-    private static final String TITLE = "Model Names";
-    private static final String DATA_TABLES_TEMPLATE = "<script type=''text/javascript'' src=''{0}''></script>\n"
-                    + "<script type=''text/javascript'' src=''{1}''></script>\n" + "<script type=''text/javascript''>\n"
-                    + "$(document).ready(function() '{' $(''#myTable'').dataTable('{'\"bPaginate\": false, \"aaSorting\": [[0, \"asc\"]], \"bStateSave\": true'}') '}')\n"
-                    + "</script>\n";
     
-    public ModelList(String jqueryUri, String datatablesUri, String modelTableName) {
-        this.jqueryUri = jqueryUri;
-        this.dataTablesUri = datatablesUri;
+    public ModelList(String modelTableName) {
         this.modelTableName = modelTableName;
     }
     
     @XmlElementWrapper(name = "ModelNames")
     @XmlElement(name = "ModelName")
     private HashSet<String> names;
-    
-    /*
-     * (non-Javadoc)
-     * 
-     * @see datawave.webservice.HtmlProvider#getTitle()
-     */
-    @Override
-    public String getTitle() {
-        return TITLE;
-    }
-    
-    /*
-     * (non-Javadoc)
-     * 
-     * @see datawave.webservice.HtmlProvider#getPageHeader()
-     */
-    @Override
-    public String getPageHeader() {
-        return getTitle();
-    }
-    
-    /*
-     * (non-Javadoc)
-     * 
-     * @see datawave.webservice.HtmlProvider#getHeadContent()
-     */
-    @Override
-    public String getHeadContent() {
-        return MessageFormat.format(DATA_TABLES_TEMPLATE, jqueryUri, dataTablesUri);
-    }
-    
-    /*
-     * (non-Javadoc)
-     * 
-     * @see datawave.webservice.HtmlProvider#getMainContent()
-     */
-    @Override
-    public String getMainContent() {
-        StringBuilder builder = new StringBuilder();
-        
-        if (this.getNames() == null || this.getNames().isEmpty()) {
-            builder.append("No models available.");
-        } else {
-            builder.append("<div>\n");
-            builder.append("<div id=\"myTable_wrapper\" class=\"dataTables_wrapper no-footer\">\n");
-            builder.append("<table id=\"myTable\" class=\"dataTable no-footer\" role=\"grid\" aria-describedby=\"myTable_info\">\n");
-            builder.append("<thead><tr><th>Model Name</th></tr></thead>");
-            builder.append("<tbody>");
-            
-            for (String name : this.getNames()) {
-                // highlight alternating rows
-                builder.append("<tr>");
-                builder.append("<td><a href=\"/DataWave/Model/").append(name).append("?modelTableName=").append(modelTableName);
-                builder.append("\">").append(name).append("</a></td>");
-                builder.append("</tr>\n");
-            }
-            builder.append("</tbody>");
-            builder.append("  </table>\n");
-            builder.append("  <div class=\"dataTables_info\" id=\"myTable_info\" role=\"status\" aria-live=\"polite\"></div>\n");
-            builder.append("</div>\n");
-            builder.append("</div>");
-        }
-        return builder.toString();
-    }
-    
 }

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -174,6 +174,10 @@
             <artifactId>accumulo-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>datatables</artifactId>
         </dependency>

--- a/service/src/main/java/datawave/microservice/dictionary/DataDictionaryController.java
+++ b/service/src/main/java/datawave/microservice/dictionary/DataDictionaryController.java
@@ -49,8 +49,8 @@ import static datawave.microservice.http.converter.protostuff.ProtostuffHttpMess
                                 url = "https://github.com/NationalSecurityAgency/datawave-dictionary-service"))
 @RestController
 @RequestMapping(path = "/data/v1",
-                produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE, PROTOSTUFF_VALUE,
-                        MediaType.TEXT_HTML_VALUE, "text/x-yaml", "application/x-yaml"})
+                produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE, PROTOSTUFF_VALUE, "text/x-yaml",
+                        "application/x-yaml"})
 @EnableConfigurationProperties(DataDictionaryProperties.class)
 public class DataDictionaryController<DESC extends DescriptionBase<DESC>,DICT extends DataDictionaryBase<DICT,META>,META extends MetadataFieldBase<META,DESC>,FIELD extends DictionaryFieldBase<FIELD,DESC>,FIELDS extends FieldsBase<FIELDS,FIELD,DESC>> {
     

--- a/service/src/main/java/datawave/microservice/dictionary/DataDictionaryWebController.java
+++ b/service/src/main/java/datawave/microservice/dictionary/DataDictionaryWebController.java
@@ -1,0 +1,134 @@
+package datawave.microservice.dictionary;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
+
+import com.codahale.metrics.annotation.Timed;
+
+import datawave.microservice.AccumuloConnectionService;
+import datawave.microservice.Connection;
+import datawave.microservice.authorization.user.ProxiedUserDetails;
+import datawave.microservice.dictionary.config.DataDictionaryProperties;
+import datawave.microservice.dictionary.config.ResponseObjectFactory;
+import datawave.microservice.dictionary.data.DataDictionary;
+import datawave.webservice.dictionary.data.DataDictionaryBase;
+import datawave.webservice.dictionary.data.DescriptionBase;
+import datawave.webservice.dictionary.data.DictionaryFieldBase;
+import datawave.webservice.dictionary.data.FieldsBase;
+import datawave.webservice.metadata.DefaultMetadataField;
+import datawave.webservice.metadata.MetadataFieldBase;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Data Dictionary Controller /v1", description = "DataWave Dictionary Operations",
+                externalDocs = @ExternalDocumentation(description = "Dictionary Service Documentation",
+                                url = "https://github.com/NationalSecurityAgency/datawave-dictionary-service"))
+@Controller
+@RequestMapping(path = "/data/v1", produces = {MediaType.TEXT_HTML_VALUE})
+@EnableConfigurationProperties(DataDictionaryProperties.class)
+public class DataDictionaryWebController<DESC extends DescriptionBase<DESC>,DICT extends DataDictionaryBase<DICT,META>,META extends MetadataFieldBase<META,DESC>,FIELD extends DictionaryFieldBase<FIELD,DESC>,FIELDS extends FieldsBase<FIELDS,FIELD,DESC>> {
+    
+    private static final String EMPTY_STR = "", SEP = ", ";
+    
+    private final DataDictionaryProperties dataDictionaryConfiguration;
+    private final DataDictionary<META,DESC,FIELD> dataDictionary;
+    private final ResponseObjectFactory<DESC,DICT,META,FIELD,FIELDS> responseObjectFactory;
+    private final AccumuloConnectionService accumuloConnectionService;
+    
+    private final Consumer<META> TRANSFORM_EMPTY_INTERNAL_FIELD_NAMES = meta -> {
+        if (meta.getInternalFieldName() == null || meta.getInternalFieldName().isEmpty()) {
+            meta.setInternalFieldName(meta.getFieldName());
+        }
+    };
+    
+    public DataDictionaryWebController(DataDictionaryProperties dataDictionaryConfiguration, DataDictionary<META,DESC,FIELD> dataDictionary,
+                    ResponseObjectFactory<DESC,DICT,META,FIELD,FIELDS> responseObjectFactory, AccumuloConnectionService accumloConnectionService) {
+        this.dataDictionaryConfiguration = dataDictionaryConfiguration;
+        this.dataDictionary = dataDictionary;
+        this.responseObjectFactory = responseObjectFactory;
+        this.accumuloConnectionService = accumloConnectionService;
+        dataDictionary.setNormalizationMap(dataDictionaryConfiguration.getNormalizerMap());
+    }
+    
+    @GetMapping("/")
+    @Timed(name = "dw.dictionary.data.get", absolute = true)
+    public ModelAndView get(@RequestParam(required = false) String modelName, @RequestParam(required = false) String modelTableName,
+                    @RequestParam(required = false) String metadataTableName, @RequestParam(name = "auths", required = false) String queryAuthorizations,
+                    @RequestParam(defaultValue = "") String dataTypeFilters, @AuthenticationPrincipal ProxiedUserDetails currentUser) throws Exception {
+        Connection connection = accumuloConnectionService.getConnection(metadataTableName, modelTableName, modelName, currentUser);
+        // If the user provides authorizations, intersect it with their actual authorizations
+        connection.setAuths(accumuloConnectionService.getDowngradedAuthorizations(queryAuthorizations, currentUser));
+        
+        Collection<String> dataTypes = (StringUtils.isBlank(dataTypeFilters) ? Collections.emptyList() : Arrays.asList(dataTypeFilters.split(",")));
+        
+        Collection<META> fields = dataDictionary.getFields(connection, dataTypes, dataDictionaryConfiguration.getNumThreads());
+        DICT dataDictionary = responseObjectFactory.getDataDictionary();
+        dataDictionary.setFields(fields);
+        // Ensure that empty internal field names will be set to the field name instead.
+        dataDictionary.transformFields(TRANSFORM_EMPTY_INTERNAL_FIELD_NAMES);
+        
+        ModelAndView mav = new ModelAndView();
+        mav.setViewName("datadictionary");
+        mav.addObject("jqueryUri", dataDictionary.getJqueryUri());
+        mav.addObject("datatablesUri", dataDictionary.getDatatablesUri());
+        
+        // To be passed to the MAV. Contains all the table content
+        List<List<String>> tableContent = new ArrayList<List<String>>();
+        for (META f : fields) {
+            List<String> row = new ArrayList<String>();
+            
+            String fieldName = (null == f.getFieldName()) ? EMPTY_STR : f.getFieldName();
+            String internalFieldName = (null == f.getInternalFieldName()) ? EMPTY_STR : f.getInternalFieldName();
+            String datatype = (null == f.getDataType()) ? EMPTY_STR : f.getDataType();
+            
+            StringBuilder types = new StringBuilder();
+            if (null != f.getTypes()) {
+                for (String forwardIndexType : f.getTypes()) {
+                    if (0 != types.length()) {
+                        types.append(SEP);
+                    }
+                    types.append(forwardIndexType);
+                }
+            }
+            row.add(fieldName);
+            row.add(internalFieldName);
+            row.add(datatype);
+            row.add(f.isIndexOnly().toString());
+            row.add(f.isForwardIndexed() ? "true" : "");
+            row.add(f.isReverseIndexed() ? "true" : "");
+            row.add(f.getTypes() != null && f.getTypes().size() > 0 ? "true" : "false");
+            row.add(types.toString());
+            row.add(((DefaultMetadataField) f).isTokenized() ? "true" : "");
+            StringBuilder descriptionSB = new StringBuilder();
+            boolean first = true;
+            for (DescriptionBase desc : f.getDescriptions()) {
+                if (!first) {
+                    descriptionSB.append(", ");
+                }
+                descriptionSB.append(desc.getMarkings()).append(" ").append(desc.getDescription());
+                first = false;
+            }
+            row.add(descriptionSB.toString());
+            row.add(f.getLastUpdated());
+            
+            tableContent.add(row);
+        }
+        mav.addObject("tableContent", tableContent);
+        
+        return mav;
+    }
+}

--- a/service/src/main/java/datawave/microservice/dictionary/DataDictionaryWebController.java
+++ b/service/src/main/java/datawave/microservice/dictionary/DataDictionaryWebController.java
@@ -108,8 +108,6 @@ public class DataDictionaryWebController<DESC extends DescriptionBase<DESC>,DICT
         
         ModelAndView mav = new ModelAndView();
         mav.setViewName("datadictionary");
-        mav.addObject("jqueryUri", dataDictionary.getJqueryUri() + "jquery.min.js");
-        mav.addObject("datatablesUri", dataDictionary.getDatatablesUri() + "jquery.dataTables.min.js");
         
         // To be passed to the MAV. Contains all the table content
         List<List<String>> tableContent = new ArrayList<List<String>>();

--- a/service/src/main/java/datawave/microservice/dictionary/DataDictionaryWebController.java
+++ b/service/src/main/java/datawave/microservice/dictionary/DataDictionaryWebController.java
@@ -83,8 +83,8 @@ public class DataDictionaryWebController<DESC extends DescriptionBase<DESC>,DICT
         
         ModelAndView mav = new ModelAndView();
         mav.setViewName("datadictionary");
-        mav.addObject("jqueryUri", dataDictionary.getJqueryUri());
-        mav.addObject("datatablesUri", dataDictionary.getDatatablesUri());
+        mav.addObject("jqueryUri", dataDictionary.getJqueryUri() + "jquery.min.js");
+        mav.addObject("datatablesUri", dataDictionary.getDatatablesUri() + "jquery.dataTables.min.js");
         
         // To be passed to the MAV. Contains all the table content
         List<List<String>> tableContent = new ArrayList<List<String>>();

--- a/service/src/main/java/datawave/microservice/dictionary/EdgeDictionaryController.java
+++ b/service/src/main/java/datawave/microservice/dictionary/EdgeDictionaryController.java
@@ -28,8 +28,8 @@ import static datawave.microservice.http.converter.protostuff.ProtostuffHttpMess
 @Slf4j
 @RestController
 @RequestMapping(path = "/edge/v1",
-                produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE, PROTOSTUFF_VALUE,
-                        MediaType.TEXT_HTML_VALUE, "text/x-yaml", "application/x-yaml"})
+                produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE, PROTOSTUFF_VALUE, "text/x-yaml",
+                        "application/x-yaml"})
 @EnableConfigurationProperties(EdgeDictionaryProperties.class)
 public class EdgeDictionaryController<EDGE extends EdgeDictionaryBase<EDGE,META>,META extends MetadataBase<META>> {
     

--- a/service/src/main/java/datawave/microservice/dictionary/EdgeDictionaryWebController.java
+++ b/service/src/main/java/datawave/microservice/dictionary/EdgeDictionaryWebController.java
@@ -1,0 +1,124 @@
+package datawave.microservice.dictionary;
+
+import static datawave.microservice.http.converter.protostuff.ProtostuffHttpMessageConverter.PROTOSTUFF_VALUE;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
+
+import com.codahale.metrics.annotation.Timed;
+
+import datawave.accumulo.util.security.UserAuthFunctions;
+import datawave.microservice.AccumuloConnectionService;
+import datawave.microservice.authorization.user.ProxiedUserDetails;
+import datawave.microservice.dictionary.config.EdgeDictionaryProperties;
+import datawave.microservice.dictionary.edge.EdgeDictionary;
+import datawave.webservice.dictionary.edge.EdgeDictionaryBase;
+import datawave.webservice.dictionary.edge.EventField;
+import datawave.webservice.dictionary.edge.MetadataBase;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+@Tag(name = "Edge Dictionary Controller /v1", description = "DataWave Edge Dictionary Operations",
+                externalDocs = @ExternalDocumentation(description = "Dictionary Service Documentation",
+                                url = "https://github.com/NationalSecurityAgency/datawave-dictionary-service"))
+@Slf4j
+@Controller
+@RequestMapping(path = "/edge/v1", produces = {MediaType.TEXT_HTML_VALUE})
+@EnableConfigurationProperties(EdgeDictionaryProperties.class)
+public class EdgeDictionaryWebController<EDGE extends EdgeDictionaryBase<EDGE,META>,META extends MetadataBase<META>> {
+    
+    private static final String SEP = ", ";
+    private final EdgeDictionaryProperties edgeDictionaryProperties;
+    private final EdgeDictionary<EDGE,META> edgeDictionary;
+    private final UserAuthFunctions userAuthFunctions;
+    private final AccumuloConnectionService accumuloConnectionService;
+    
+    public EdgeDictionaryWebController(EdgeDictionaryProperties edgeDictionaryProperties, EdgeDictionary<EDGE,META> edgeDictionary,
+                    UserAuthFunctions userAuthFunctions, AccumuloConnectionService accumloConnectionService) {
+        this.edgeDictionaryProperties = edgeDictionaryProperties;
+        this.edgeDictionary = edgeDictionary;
+        this.userAuthFunctions = userAuthFunctions;
+        this.accumuloConnectionService = accumloConnectionService;
+    }
+    
+    /**
+     * Returns the EdgeDictionary given a metadata table and authorizations
+     *
+     * @param metadataTableName
+     *            Name of metadata table (Optional)
+     * @param queryAuthorizations
+     *            Authorizations to use
+     * @return The ModelAndView for edgedictionary.html which contains the edge dictionary fields.
+     * @throws Exception
+     *             if there is any problem retrieving the edge dictionary from Accumulo
+     */
+    @GetMapping("/")
+    @Timed(name = "dw.dictionary.edge.get", absolute = true)
+    public ModelAndView get(@RequestParam(required = false) String metadataTableName,
+                    @RequestParam(name = "auths", required = false) String queryAuthorizations, @AuthenticationPrincipal ProxiedUserDetails currentUser)
+                    throws Exception {
+        log.info("EDGEDICTIONARY: entered rest endpoint");
+        if (null == metadataTableName || StringUtils.isBlank(metadataTableName)) {
+            metadataTableName = edgeDictionaryProperties.getMetadataTableName();
+        }
+        
+        EDGE edgeDict = edgeDictionary.getEdgeDictionary(metadataTableName, accumuloConnectionService.getConnection().getConnector(),
+                        accumuloConnectionService.getDowngradedAuthorizations(queryAuthorizations, currentUser), edgeDictionaryProperties.getNumThreads());
+        
+        log.info("EDGEDICTIONARY: returning edge dictionary");
+        
+        ModelAndView mav = new ModelAndView();
+        mav.setViewName("edgedictionary");
+        
+        int x = 0;
+        String highlight;
+        // To be passed to the MAV. Contains all the table content
+        List<List<String>> tableContent = new ArrayList<List<String>>();
+        for (MetadataBase<META> metadata : edgeDict.getMetadataList()) {
+            List<String> row = new ArrayList<String>();
+            // highlight alternating rows
+            if (x % 2 == 0) {
+                highlight = "highlight";
+            } else {
+                highlight = "";
+            }
+            x++;
+            
+            String type = metadata.getEdgeType();
+            String relationship = metadata.getEdgeRelationship();
+            String collect = metadata.getEdgeAttribute1Source();
+            StringBuilder fieldBuilder = new StringBuilder();
+            for (EventField field : metadata.getEventFields()) {
+                fieldBuilder.append(field).append(SEP);
+            }
+            
+            String fieldNames = fieldBuilder.toString().substring(0, fieldBuilder.length() - 2);
+            String date = metadata.getStartDate();
+            
+            // "highlight" if row should be highlighted, "" otherwise
+            row.add(highlight);
+            // The data for the row
+            row.add(type);
+            row.add(relationship);
+            row.add(collect);
+            row.add(fieldNames);
+            row.add(date);
+            
+            tableContent.add(row);
+        }
+        mav.addObject("tableContent", tableContent);
+        
+        return mav;
+    }
+}

--- a/service/src/main/java/datawave/microservice/dictionary/config/DictionaryServiceConfiguration.java
+++ b/service/src/main/java/datawave/microservice/dictionary/config/DictionaryServiceConfiguration.java
@@ -70,8 +70,7 @@ public class DictionaryServiceConfiguration {
         return new ResponseObjectFactory<DefaultDescription,DefaultDataDictionary,DefaultMetadataField,DefaultDictionaryField,DefaultFields>() {
             @Override
             public DefaultDataDictionary getDataDictionary() {
-                return new DefaultDataDictionary(datawaveServerProperties.getCdnUri() + "webjars/jquery/",
-                                datawaveServerProperties.getCdnUri() + "webjars/datatables/js/");
+                return new DefaultDataDictionary();
             }
             
             @Override

--- a/service/src/main/java/datawave/microservice/model/ModelController.java
+++ b/service/src/main/java/datawave/microservice/model/ModelController.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping(path = "/model",
                 produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_XML_VALUE,
-                        ProtostuffHttpMessageConverter.PROTOSTUFF_VALUE, MediaType.TEXT_HTML_VALUE, "text/x-yaml", "application/x-yaml"})
+                        ProtostuffHttpMessageConverter.PROTOSTUFF_VALUE, "text/x-yaml", "application/x-yaml"})
 @Secured({"AuthorizedUser", "AuthorizedQueryServer", "InternalUser", "Administrator", "JBossAdministrator"})
 @EnableConfigurationProperties(ModelProperties.class)
 public class ModelController {
@@ -81,7 +81,7 @@ public class ModelController {
     public ModelList listModelNames(@RequestParam(defaultValue = DEFAULT_MODEL_TABLE_NAME) String modelTableName,
                     @AuthenticationPrincipal ProxiedUserDetails currentUser) {
         
-        ModelList response = new ModelList(jqueryUri, dataTablesUri, modelTableName);
+        ModelList response = new ModelList(modelTableName);
         HashSet<String> modelNames = new HashSet<>();
         List<Key> keys;
         try {
@@ -187,7 +187,7 @@ public class ModelController {
     @GetMapping("/{name}")
     public Model getModel(@RequestParam String name, @RequestParam(defaultValue = DEFAULT_MODEL_TABLE_NAME) String modelTableName,
                     @AuthenticationPrincipal ProxiedUserDetails currentUser) {
-        Model response = new Model(jqueryUri, dataTablesUri);
+        Model response = new Model();
         List<Key> keys;
         try {
             keys = accumloConnectionService.getKeys(modelTableName, currentUser, name);

--- a/service/src/main/java/datawave/microservice/model/ModelWebController.java
+++ b/service/src/main/java/datawave/microservice/model/ModelWebController.java
@@ -1,0 +1,170 @@
+package datawave.microservice.model;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.data.Key;
+import org.apache.accumulo.core.security.Authorizations;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.ModelAndView;
+
+import com.google.common.collect.Sets;
+
+import datawave.microservice.AccumuloConnectionService;
+import datawave.microservice.authorization.user.ProxiedUserDetails;
+import datawave.microservice.http.converter.protostuff.ProtostuffHttpMessageConverter;
+import datawave.microservice.model.config.ModelProperties;
+import datawave.webservice.model.FieldMapping;
+import datawave.webservice.model.Model;
+import datawave.webservice.model.ModelKeyParser;
+import datawave.webservice.model.ModelList;
+import datawave.webservice.query.exception.DatawaveErrorCode;
+import datawave.webservice.query.exception.QueryException;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Service that supports manipulation of models. The models are contained in the data dictionary table.
+ */
+@Tag(name = "Model Controller /v1", description = "DataWave Model Operations",
+                externalDocs = @ExternalDocumentation(description = "Dictionary Service Documentation",
+                                url = "https://github.com/NationalSecurityAgency/datawave-dictionary-service"))
+@Slf4j
+@Controller
+@RequestMapping(path = "/model", produces = {MediaType.TEXT_HTML_VALUE})
+@Secured({"AuthorizedUser", "AuthorizedQueryServer", "InternalUser", "Administrator", "JBossAdministrator"})
+@EnableConfigurationProperties(ModelProperties.class)
+public class ModelWebController {
+    
+    private final String dataTablesUri;
+    private final String jqueryUri;
+    private final AccumuloConnectionService accumloConnectionService;
+    
+    public static final String DEFAULT_MODEL_TABLE_NAME = "DatawaveMetadata";
+    private static final HashSet<String> RESERVED_COLF_VALUES = Sets.newHashSet("e", "i", "ri", "f", "tf", "m", "desc", "edge", "t", "n", "h");
+    
+    public ModelWebController(ModelProperties modelProperties, AccumuloConnectionService accumloConnectionService) {
+        this.dataTablesUri = modelProperties.getDefaultTableName();
+        this.jqueryUri = modelProperties.getJqueryUri();
+        this.accumloConnectionService = accumloConnectionService;
+    }
+    
+    /**
+     * Get the names of the models
+     *
+     * @param modelTableName
+     *            name of the table that contains the model
+     * @return the ModelAndView
+     * @RequestHeader X-ProxiedEntitiesChain use when proxying request for user
+     *            
+     * @HTTP 200 success
+     * @HTTP 500 internal server error
+     */
+    @GetMapping("/list") // If we get to change to follow true REST standard, this would just be / and remain a GET
+    public ModelAndView listModelNames(@RequestParam(defaultValue = DEFAULT_MODEL_TABLE_NAME) String modelTableName,
+                    @AuthenticationPrincipal ProxiedUserDetails currentUser) {
+        
+        ModelList modelList = new ModelList(modelTableName);
+        ModelAndView mav = new ModelAndView();
+        HashSet<String> modelNames = new HashSet<>();
+        List<Key> keys = null;
+        
+        mav.setViewName("modelnames");
+        
+        try {
+            keys = accumloConnectionService.getKeys(modelTableName, currentUser, "");
+        } catch (TableNotFoundException e) {
+            QueryException qe = new QueryException(DatawaveErrorCode.MODEL_NAME_LIST_ERROR, e);
+            log.error(qe.getMessage());
+            modelList.addException(qe.getBottomQueryException());
+            return mav; // Return the MAV without data
+        }
+        
+        Set<String> colFamilies = keys.stream().map(k -> k.getColumnFamily().toString()).filter(colFamily -> !RESERVED_COLF_VALUES.contains(colFamily))
+                        .collect(Collectors.toSet());
+        
+        for (String colf : colFamilies) {
+            String[] parts = colf.split(ModelKeyParser.NULL_BYTE);
+            if (parts.length == 1) {
+                modelNames.add(colf);
+            } else if (parts.length == 2) {
+                modelNames.add(parts[0]);
+            }
+        }
+        
+        modelList.setNames(modelNames);
+        
+        mav.addObject("names", modelList.getNames());
+        mav.addObject("modelTableName", modelList.getModelTableName());
+        
+        return mav;
+    }
+    
+    /**
+     * Retrieve the model and all of its mappings
+     *
+     * @param name
+     *            model name
+     * @param modelTableName
+     *            name of the table that contains the model
+     * @return the ModelAndView
+     * @RequestHeader X-ProxiedEntitiesChain use when proxying request for user
+     *            
+     * @HTTP 200 success
+     * @HTTP 404 model not found
+     * @HTTP 500 internal server error
+     */
+    @GetMapping("/{name}")
+    public ModelAndView getModel(@RequestParam String name, @RequestParam(defaultValue = DEFAULT_MODEL_TABLE_NAME) String modelTableName,
+                    @AuthenticationPrincipal ProxiedUserDetails currentUser) {
+        Model model = new Model();
+        ModelAndView mav = new ModelAndView();
+        List<List<String>> tableContent = new ArrayList<List<String>>();
+        
+        mav.setViewName("modeldescription");
+        
+        List<Key> keys = null;
+        try {
+            keys = accumloConnectionService.getKeys(modelTableName, currentUser, name);
+        } catch (TableNotFoundException e) {
+            QueryException qe = new QueryException(DatawaveErrorCode.MODEL_NAME_LIST_ERROR, e);
+            log.error(qe.getMessage());
+            model.addException(qe.getBottomQueryException());
+            return mav; // Return the MAV without data
+        }
+        
+        Set<Authorizations> auths = accumloConnectionService.getConnection(modelTableName, name, currentUser).getAuths();
+        TreeSet<FieldMapping> fields = model.getFields();
+        keys.forEach(k -> fields.add(ModelKeyParser.parseKey(k, auths)));
+        model.setName(name);
+        
+        for (FieldMapping fieldMapping : fields) {
+            List<String> row = new ArrayList<String>();
+            row.add(fieldMapping.getColumnVisibility());
+            row.add(fieldMapping.getFieldName());
+            row.add(fieldMapping.getDatatype());
+            row.add(fieldMapping.getModelFieldName());
+            row.add(fieldMapping.getDirection().getValue().toUpperCase());
+            tableContent.add(row);
+        }
+        
+        mav.addObject("tableContent", tableContent);
+        
+        return mav;
+    }
+}

--- a/service/src/main/resources/templates/datadictionary.html
+++ b/service/src/main/resources/templates/datadictionary.html
@@ -4,7 +4,7 @@
 	<title>DATAWAVE - Data Dictionary</title>
 	<!--/*
     Loads jQuery, DataTables, some CSS elements for DataTables, and executes `.dataTable()` on the HTML table in the payload.
-    Pagination on the table is turned off, we do an ascending sort on the 1st column (field name) (this is done by default), 
+    Pagination on the table is turned off, we do an ascending sort on the 1st column (field name), 
 	and a cookie is saved in the browser that will leave the last sort in place upon revisit of the page.
 	*/-->
 	<link rel="stylesheet" type="text/css" href="/dictionary/css/screen.css" media="screen">
@@ -19,6 +19,9 @@
 		$(document).ready(function() { 
 			$('#myTable').dataTable({
 				"bPaginate": false, 
+				"aaSorting": [
+					[0, "asc"]
+				],
 				"bStateSave": true
 			});
 			$('table th').resizable({

--- a/service/src/main/resources/templates/datadictionary.html
+++ b/service/src/main/resources/templates/datadictionary.html
@@ -1,4 +1,3 @@
-<!DOCTYPE HTML>
 <html xmlns:th="http:/>/www.thymeleaf.org">
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">

--- a/service/src/main/resources/templates/datadictionary.html
+++ b/service/src/main/resources/templates/datadictionary.html
@@ -1,0 +1,90 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http:/>/www.thymeleaf.org">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<title>DATAWAVE - Data Dictionary</title>
+	<!--/*
+    Loads jQuery, DataTables, some CSS elements for DataTables, and executes `.dataTable()` on the HTML table in the payload.
+    Pagination on the table is turned off, we do an ascending sort on the 1st column (field name) (this is done by default), 
+	and a cookie is saved in the browser that will leave the last sort in place upon revisit of the page.
+	*/-->
+	<link rel="stylesheet" type="text/css" href="/dictionary/css/screen.css" media="screen">
+	
+	<script type="text/javascript">
+		const jqueryScript = document.createElement('script');
+		const datatablesScript = document.createElement('script');
+		
+		jqueryScript.type = "text/javascript";
+		jqueryScript.src = "[[${jqueryUri}]]jquery.min.js";
+
+		document.head.appendChild(jqueryScript);
+
+		// Wait for jqueryScript to fully load before loading the datatables script
+		// (execution of jquery.dataTables.min.js may fail otherwise)
+		jqueryScript.addEventListener("load", function() {
+			datatablesScript.type = "text/javascript";
+			datatablesScript.src = "[[${datatablesUri}]]jquery.dataTables.min.js";
+
+			document.head.appendChild(datatablesScript);
+		});
+		// Wait for datatables script to fully load before calling the dataTable() function on the table
+		// (execution of $(document).ready or $('#myTable').dataTable may fail otherwise)
+		datatablesScript.addEventListener("load", function() {
+			$(document).ready(function() { 
+				$('#myTable').dataTable({
+					"bPaginate": false, 
+					"bStateSave": true
+				});
+				setTimeout( function() { 
+					$('#myTable').find("td").css("word-break", "break-word"); 
+				}, 4000); 
+			});
+		});
+	</script>
+</head>
+<body>
+	<h1>Data Dictionary</h1>
+	<div>
+		<p style="width:60%; margin-left: auto; margin-right: auto;">
+		When a value is present in the forward index types, this means that a field is indexed and informs you how your query terms will be treated 
+		(e.g. text, number, IPv4 address, etc). The same applies for the reverse index types with the caveat that you can also query these fields using 
+		leading wildcards. Fields that are marked as 'Index only' will not appear in a result set unless explicitly queried on. Index only fields are 
+		typically composite fields, derived from actual data, created by the software to make querying easier.
+		</p>
+	</div>
+		<table id="myTable">
+			<thead>
+				<tr>
+					<th>FieldName</th>
+					<th>Internal FieldName</th>
+					<th>DataType</th>
+					<th>Index only</th>
+					<th>Forward Indexed</th>
+					<th>Reverse Indexed</th>
+					<th>Normalized</th>
+					<th>Types</th>
+					<th>Tokenized</th>
+					<th>Description</th>
+					<th>LastUpdated</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr th:each="row : ${tableContent}">
+					<td th:text="${row[0]}"></td>
+					<td th:text="${row[1]}"></td>
+					<td th:text="${row[2]}"></td>
+					<td th:text="${row[3]}"></td>
+					<td th:text="${row[4]}"></td>
+					<td th:text="${row[5]}"></td>
+					<td th:text="${row[6]}"></td>
+					<td th:text="${row[7]}"></td>
+					<td th:text="${row[8]}"></td>
+					<td th:text="${row[9]}"></td>
+					<td th:text="${row[10]}"></td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+	<br>
+</body>
+</html>

--- a/service/src/main/resources/templates/datadictionary.html
+++ b/service/src/main/resources/templates/datadictionary.html
@@ -9,36 +9,17 @@
 	and a cookie is saved in the browser that will leave the last sort in place upon revisit of the page.
 	*/-->
 	<link rel="stylesheet" type="text/css" href="/dictionary/css/screen.css" media="screen">
-	
+	<script type="text/javascript" th:src="${jqueryUri}"></script>
+	<script type="text/javascript" th:src="${datatablesUri}"></script>
 	<script type="text/javascript">
-		const jqueryScript = document.createElement('script');
-		const datatablesScript = document.createElement('script');
-		
-		jqueryScript.type = "text/javascript";
-		jqueryScript.src = "[[${jqueryUri}]]jquery.min.js";
-
-		document.head.appendChild(jqueryScript);
-
-		// Wait for jqueryScript to fully load before loading the datatables script
-		// (execution of jquery.dataTables.min.js may fail otherwise)
-		jqueryScript.addEventListener("load", function() {
-			datatablesScript.type = "text/javascript";
-			datatablesScript.src = "[[${datatablesUri}]]jquery.dataTables.min.js";
-
-			document.head.appendChild(datatablesScript);
-		});
-		// Wait for datatables script to fully load before calling the dataTable() function on the table
-		// (execution of $(document).ready or $('#myTable').dataTable may fail otherwise)
-		datatablesScript.addEventListener("load", function() {
-			$(document).ready(function() { 
-				$('#myTable').dataTable({
-					"bPaginate": false, 
-					"bStateSave": true
-				});
-				setTimeout( function() { 
-					$('#myTable').find("td").css("word-break", "break-word"); 
-				}, 4000); 
+		$(document).ready(function() { 
+			$('#myTable').dataTable({
+				"bPaginate": false, 
+				"bStateSave": true
 			});
+			setTimeout( function() { 
+				$('#myTable').find("td").css("word-break", "break-word"); 
+			}, 4000); 
 		});
 	</script>
 </head>

--- a/service/src/main/resources/templates/datadictionary.html
+++ b/service/src/main/resources/templates/datadictionary.html
@@ -8,17 +8,66 @@
 	and a cookie is saved in the browser that will leave the last sort in place upon revisit of the page.
 	*/-->
 	<link rel="stylesheet" type="text/css" href="/dictionary/css/screen.css" media="screen">
-	<script type="text/javascript" th:src="${jqueryUri}"></script>
-	<script type="text/javascript" th:src="${datatablesUri}"></script>
+	<script type="text/javascript" th:src="@{{baseUri}/dictionary/webjars/jquery/jquery.min.js(baseUri=${@environment.getProperty('server.cdnUri')})}"></script>
+	<!--/*
+	jquery-ui script and css needed for allowing the table columns to be resized by the user
+	*/-->
+	<script type="text/javascript" src="https://code.jquery.com/ui/1.9.2/jquery-ui.js"></script>
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/ui/1.9.2/themes/base/jquery-ui.css">
+	<script type="text/javascript" th:src="@{{baseUri}/dictionary/webjars/datatables/js/jquery.dataTables.min.js(baseUri=${@environment.getProperty('server.cdnUri')})}"></script>
 	<script type="text/javascript">
 		$(document).ready(function() { 
 			$('#myTable').dataTable({
 				"bPaginate": false, 
 				"bStateSave": true
 			});
-			setTimeout( function() { 
-				$('#myTable').find("td").css("word-break", "break-word"); 
-			}, 4000); 
+			$('table th').resizable({
+				handles: 'e'
+			});
+			$('#myTable').find("td").css("word-break", "break-word");
+			// Create a new div under the filter search div. Contains the info for how the table is sorted
+			function createSortedByDiv() {
+				var sortedByDiv = document.createElement('div');
+				const textContent = document.createTextNode('Table sorted by ');
+				const sortingInfo = document.createElement('span');
+				sortingInfo.setAttribute('id', 'sortedBy');
+				sortedByDiv.appendChild(textContent);
+				sortedByDiv.appendChild(sortingInfo);
+				sortedByDiv.setAttribute('style', 'padding: 5px;');
+				const tableFilterDiv = document.getElementById('myTable_filter');
+				tableFilterDiv.parentNode.insertBefore(sortedByDiv, tableFilterDiv.nextSibling);
+			}
+			// Update the text to display which column is currently being used to sort the table and in which order
+			window.updateSortingInfo = function updateSortingInfo() {
+				var table = document.getElementById('myTable');
+				var tableHeaders = table.getElementsByTagName('tr')[0];
+				var cols = tableHeaders.children;
+				for (let i = 0; i < cols.length; i++) {
+					let className = cols[i].getAttribute('class');
+					let header = cols[i].innerHTML;
+					if (className.includes('sorting_asc')) {
+						document.getElementById('sortedBy').innerHTML = `<strong>${header}</strong> in <strong>ascending</strong> order`;
+						break;
+					}
+					else if (className.includes('sorting_desc')) {
+						document.getElementById('sortedBy').innerHTML = `<strong>${header}</strong> in <strong>descending</strong> order`;
+						break;
+					}
+				}
+			}
+			// Add onclick events for each of the table headers to call updateSortingInfo()
+			function addOnClickEvents() {
+				var table = document.getElementById('myTable');
+				var tableHeaders = table.getElementsByTagName('tr')[0];
+				var cols = tableHeaders.children;
+				for (let i = 0; i < cols.length; i++) {
+					cols[i].setAttribute('onclick', 'updateSortingInfo();');
+				}
+			}
+			// Initial calls for inital page setup
+			createSortedByDiv();
+			addOnClickEvents();
+			updateSortingInfo();
 		});
 	</script>
 </head>

--- a/service/src/main/resources/templates/descriptions.html
+++ b/service/src/main/resources/templates/descriptions.html
@@ -1,0 +1,24 @@
+<html xmlns:th="http:/>/www.thymeleaf.org">
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <title>DATAWAVE - Field Descriptions</title>
+    <link rel="stylesheet" type="text/css" href="/dictionary/css/screen.css" media="screen">
+</head>
+<body>
+    <h1>Field Descriptions</h1>
+    <table>
+        <tr>
+            <th>Datatype</th>
+            <th>FieldName</th>
+            <th>Description</th>
+        </tr>
+
+        <tr th:class="${row[0]}" th:each="row : ${tableContent}">
+            <td th:text="${row[1]}"></td>
+            <td th:text="${row[2]}"></td>
+            <td th:text="${row[3]}"></td>
+        </tr>
+        
+    </table>
+</body>
+</html>

--- a/service/src/main/resources/templates/edgedictionary.html
+++ b/service/src/main/resources/templates/edgedictionary.html
@@ -1,0 +1,40 @@
+<html xmlns:th="http:/>/www.thymeleaf.org">
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <title>DATAWAVE - Edge Dictionary</title>
+    <link rel="stylesheet" type="text/css" href="/dictionary/css/screen.css" media="screen">
+</head>
+<body>
+    <h1>Edge Dictionary</h1>
+    <div>
+        <ul>
+            <li class="left">Edge Type: Defined either by Datawave Configuration files or Edge enrichment field.</li>
+            <li class="left">Edge Relationship: Defined by Datawave Configuration files</li>
+            <li class="left">Edge Attribute1 Source: Defined by Datawave Configuration files and optional attributes Attribute2 and Attribute3</li>
+            <li class="left">Fields: List of Field Name pairs used to generate this edge type.</li>
+            <li class="left">Fields Format:<pre>[Source Field, Target Field | Enrichment Field=Enrichment Field Value]</pre></li>
+            <li class="left">Date: start date of edge type creation, format: yyyyMMdd</li>
+        </ul>
+    </div>
+    <table id="myTable" class="creds">
+        <thead>
+            <tr>
+                <th>Edge Type</th>
+                <th>Edge Relationship</th>
+                <th>Edge Attribute1 Source</th>
+                <th>Fields</th>
+                <th>Date</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr th:class="${row[0]}" th:each="row : ${tableContent}">
+                <td th:text="${row[1]}"></td>
+                <td th:text="${row[2]}"></td>
+                <td th:text="${row[3]}"></td>
+                <td th:text="${row[4]}"></td>
+                <td th:text="${row[5]}"></td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/service/src/main/resources/templates/modeldescription.html
+++ b/service/src/main/resources/templates/modeldescription.html
@@ -1,0 +1,43 @@
+<html xmlns:th="http:/>/www.thymeleaf.org">
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <title>DATAWAVE - Model Description</title>
+    <link rel="stylesheet" type="text/css" href="/dictionary/css/screen.css" media="screen">
+    <script type="text/javascript" th:src="@{{baseUri}/dictionary/webjars/jquery/jquery.min.js(baseUri=${@environment.getProperty('server.cdnUri')})}"></script>
+    <script type="text/javascript" th:src="@{{baseUri}/dictionary/webjars/datatables/js/jquery.dataTables.min.js(baseUri=${@environment.getProperty('server.cdnUri')})}"></script>
+    <script type="text/javascript">
+        $(document).ready(function () {
+            $('#myTable').dataTable({
+                "bPaginate": false,
+                "aaSorting": [
+                    [3, "asc"]
+                ],
+                "bStateSave": true
+            });
+        });
+    </script>
+</head>
+<body>
+    <h1>Model Description</h1>
+    <table id="myTable">
+        <thead>
+            <tr>
+                <th>Visibility</th>
+                <th>FieldName</th>
+                <th>DataType</th>
+                <th>ModelFieldName</th>
+                <th>Direction</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr th:each="row : ${tableContent}">
+                <td th:text="${row[0]}"></td>
+                <td th:text="${row[1]}"></td>
+                <td th:text="${row[2]}"></td>
+                <td th:text="${row[3]}"></td>
+                <td th:text="${row[4]}"></td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/service/src/main/resources/templates/modelnames.html
+++ b/service/src/main/resources/templates/modelnames.html
@@ -1,0 +1,42 @@
+<html xmlns:th="http:/>/www.thymeleaf.org">
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <title>DATAWAVE - Model Names</title>
+    <link rel="stylesheet" type="text/css" href="/dictionary/css/screen.css" media="screen">
+    <script type="text/javascript" th:src="@{{baseUri}/dictionary/webjars/jquery/jquery.min.js(baseUri=${@environment.getProperty('server.cdnUri')})}"></script>
+    <script type="text/javascript" th:src="@{{baseUri}/dictionary/webjars/datatables/js/jquery.dataTables.min.js(baseUri=${@environment.getProperty('server.cdnUri')})}"></script>
+    <script type="text/javascript">
+        $(document).ready(function () {
+            $('#myTable').dataTable({ 
+                "bPaginate": false, 
+                "aaSorting": [
+                    [0, "asc"]
+                ],
+                "bStateSave": true 
+            });
+        });
+    </script>
+</head>
+<body>
+    <h1>Model Names</h1>
+    <div>
+        <table id="myTable">
+            <thead>
+                <tr>
+                    <th>Model Name</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr th:each="name : ${names}">
+                    <td>
+                        <!--/*
+                            Link to "/model/<name>?name=<name>&modelTableName=<modelTableName>"
+                        */-->
+                        <a th:text="${name}" th:href="@{/model/{name1}(name1=${name},name=${name},modelTableName=${modelTableName})}"></a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Dictionary Service should no longer use HtmlProvider interface and a stringbuilder to build the HTML. Should use Spring MVC instead. ([Datawave Issue 1598](https://github.com/NationalSecurityAgency/datawave/issues/1598)). This PR also fixes [Datawave Issue 1634](https://github.com/NationalSecurityAgency/datawave/issues/1634).

Changes:
- HTML for the Data Dictionary, Edge Dictionary, Field Description, and Model pages are no longer served by HtmlProvider.
  Instead, Spring MVC with HTML template files are used.
- DataDictionaryController, EdgeDictionaryController, and ModelController no longer handle HTML. Handled by
  new classes DataDictionaryWebController, EdgeDictionaryWebController, and ModelWebController now.
- Added thymeleaf dependency to service/pom.xml
- Data Dictionary page columns can now be resized by the user and page now shows how the table is being sorted.

Model Pages (/list and /{name}) specifically:

- Fixed issue with jQuery scripts not being loaded properly on these pages (/list and /{name})
- Entries of table in /list were originally linking to "/DataWave/Model/{name}?modelTableName={modelTableName}" which I believe doesn't exist. I think this was meant to link to the /{name} endpoint (the Model Description page) so I changed it to "/model/{name}?name={name}&modelTableName={modelTableName}". This may not have been what was intended so let me know.