### PR TITLE
Add more descriptive names to unmapped datatypes in data dictionary

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,6 +21,7 @@
         <version.base-responses>3.0.0</version.base-responses>
         <version.guava>31.1-jre</version.guava>
         <version.microservice.metadata-utils>3.0.0</version.microservice.metadata-utils>
+        <version.microservice.type-utils>2.0.3-SNAPSHOT</version.microservice.type-utils>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -59,6 +60,21 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            <dependency>
+                <groupId>gov.nsa.datawave.microservice</groupId>
+                <artifactId>type-utils</artifactId>
+                <version>${version.microservice.type-utils}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>log4j</artifactId>
+                        <groupId>log4j</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>avro</artifactId>
+                        <groupId>org.apache.avro</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -73,6 +89,10 @@
         <dependency>
             <groupId>gov.nsa.datawave.microservice</groupId>
             <artifactId>metadata-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>gov.nsa.datawave.microservice</groupId>
+            <artifactId>type-utils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/api/src/main/java/datawave/webservice/dictionary/data/DefaultDataDictionary.java
+++ b/api/src/main/java/datawave/webservice/dictionary/data/DefaultDataDictionary.java
@@ -206,7 +206,6 @@ public class DefaultDataDictionary extends DataDictionaryBase<DefaultDataDiction
         builder.append("the caveat that you can also query these fields using leading wildcards. Fields that are marked as 'Index only' will not ");
         builder.append("appear in a result set unless explicitly queried on. Index only fields are typically composite fields, derived from actual data, ");
         builder.append("created by the software to make querying easier.</p>");
-        builder.append("<p style=\"width:60%; margin-left: auto; margin-right: auto;\">Note: Types that are designated a '*' signify they are not a normalized type.</p>");
         builder.append("</div>");
         builder.append("<table id=\"myTable\">\n");
         

--- a/api/src/main/java/datawave/webservice/dictionary/data/DefaultDataDictionary.java
+++ b/api/src/main/java/datawave/webservice/dictionary/data/DefaultDataDictionary.java
@@ -206,6 +206,7 @@ public class DefaultDataDictionary extends DataDictionaryBase<DefaultDataDiction
         builder.append("the caveat that you can also query these fields using leading wildcards. Fields that are marked as 'Index only' will not ");
         builder.append("appear in a result set unless explicitly queried on. Index only fields are typically composite fields, derived from actual data, ");
         builder.append("created by the software to make querying easier.</p>");
+        builder.append("<p style=\"width:60%; margin-left: auto; margin-right: auto;\">Note: Types that are designated a '*' signify they are not a normalized type.</p>");
         builder.append("</div>");
         builder.append("<table id=\"myTable\">\n");
         

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -22,7 +22,7 @@
         <version.accumulo>2.1.1</version.accumulo>
         <version.curator>5.2.0</version.curator>
         <version.in-memory-accumulo>3.0.1</version.in-memory-accumulo>
-        <version.microservice.dictionary-api>3.0.0</version.microservice.dictionary-api>
+        <version.microservice.dictionary-api>3.0.1-SNAPSHOT</version.microservice.dictionary-api>
         <version.microservice.starter>3.0.0</version.microservice.starter>
         <version.microservice.starter-metadata>2.0.0</version.microservice.starter-metadata>
         <version.webjars.datatables>1.11.4</version.webjars.datatables>

--- a/service/src/main/java/datawave/microservice/AccumuloConnectionService.java
+++ b/service/src/main/java/datawave/microservice/AccumuloConnectionService.java
@@ -20,7 +20,7 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.iterators.user.RegExFilter;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 

--- a/service/src/main/java/datawave/microservice/dictionary/DataDictionaryController.java
+++ b/service/src/main/java/datawave/microservice/dictionary/DataDictionaryController.java
@@ -11,7 +11,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.annotation.Secured;
@@ -73,7 +73,6 @@ public class DataDictionaryController<DESC extends DescriptionBase<DESC>,DICT ex
         this.dataDictionary = dataDictionary;
         this.responseObjectFactory = responseObjectFactory;
         this.accumuloConnectionService = accumloConnectionService;
-        dataDictionary.setNormalizationMap(dataDictionaryConfiguration.getNormalizerMap());
     }
     
     /**

--- a/service/src/main/java/datawave/microservice/dictionary/EdgeDictionaryController.java
+++ b/service/src/main/java/datawave/microservice/dictionary/EdgeDictionaryController.java
@@ -2,7 +2,7 @@ package datawave.microservice.dictionary;
 
 import static datawave.microservice.http.converter.protostuff.ProtostuffHttpMessageConverter.PROTOSTUFF_VALUE;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/service/src/main/java/datawave/microservice/dictionary/data/DataDictionary.java
+++ b/service/src/main/java/datawave/microservice/dictionary/data/DataDictionary.java
@@ -14,10 +14,6 @@ import datawave.webservice.metadata.MetadataFieldBase;
 
 public interface DataDictionary<META extends MetadataFieldBase<META,DESC>,DESC extends DescriptionBase<DESC>,FIELD extends DictionaryFieldBase<FIELD,DESC>> {
     
-    Map<String,String> getNormalizationMap();
-    
-    void setNormalizationMap(Map<String,String> normalizationMap);
-    
     Collection<META> getFields(Connection connectionConfig, Collection<String> dataTypeFilters, int numThreads) throws Exception;
     
     void setDescription(Connection connectionConfig, FIELD description) throws Exception;

--- a/service/src/main/java/datawave/microservice/dictionary/data/DataDictionaryImpl.java
+++ b/service/src/main/java/datawave/microservice/dictionary/data/DataDictionaryImpl.java
@@ -36,7 +36,6 @@ public class DataDictionaryImpl implements DataDictionary<DefaultMetadataField,D
     private final ResponseObjectFactory<DefaultDescription,DefaultDataDictionary,DefaultMetadataField,DefaultDictionaryField,DefaultFields> responseObjectFactory;
     private final MetadataHelperFactory metadataHelperFactory;
     private final MetadataDescriptionsHelperFactory<DefaultDescription> metadataDescriptionsHelperFactory;
-    private Map<String,String> normalizationMap = Maps.newHashMap();
     
     public DataDictionaryImpl(MarkingFunctions markingFunctions,
                     ResponseObjectFactory<DefaultDescription,DefaultDataDictionary,DefaultMetadataField,DefaultDictionaryField,DefaultFields> responseObjectFactory,
@@ -45,16 +44,6 @@ public class DataDictionaryImpl implements DataDictionary<DefaultMetadataField,D
         this.responseObjectFactory = responseObjectFactory;
         this.metadataHelperFactory = metadataHelperFactory;
         this.metadataDescriptionsHelperFactory = metadataDescriptionsHelperFactory;
-    }
-    
-    @Override
-    public Map<String,String> getNormalizationMap() {
-        return normalizationMap;
-    }
-    
-    @Override
-    public void setNormalizationMap(Map<String,String> normalizationMap) {
-        this.normalizationMap = normalizationMap;
     }
     
     /**
@@ -76,8 +65,7 @@ public class DataDictionaryImpl implements DataDictionary<DefaultMetadataField,D
     @Override
     public Collection<DefaultMetadataField> getFields(Connection connectionConfig, Collection<String> dataTypeFilters, int numThreads) throws Exception {
         Map<String,String> aliases = getAliases(connectionConfig);
-        DefaultMetadataFieldScanner scanner = new DefaultMetadataFieldScanner(markingFunctions, responseObjectFactory, normalizationMap, connectionConfig,
-                        numThreads);
+        DefaultMetadataFieldScanner scanner = new DefaultMetadataFieldScanner(markingFunctions, responseObjectFactory, connectionConfig, numThreads);
         return scanner.getFields(aliases, dataTypeFilters);
     }
     

--- a/service/src/main/java/datawave/microservice/metadata/DefaultMetadataFieldScanner.java
+++ b/service/src/main/java/datawave/microservice/metadata/DefaultMetadataFieldScanner.java
@@ -264,22 +264,21 @@ public class DefaultMetadataFieldScanner {
             currField.getDescriptions().add(description);
         }
         
-        // Receives a type that does not have a normalized version, which then is processed and returned.
+        // Receives a type that is not in the normalizationMap, which then is processed and returned.
         // Ensures first letter of the type is always capitalized.
         // Ensures redundant terminology like 'Type' is removed.
-        // Appends a '*' at the end of the type to signify the type does not have a normalized version.
-        private String determineUknownType(String unknown) {
+        private String determineUnknownType(String unknown) {
             String[] unknownType = unknown.split("\\.");
-            return StringUtils.capitalize(unknownType[unknownType.length - 1].replace("Type", "")) + "*";
+            return StringUtils.capitalize(unknownType[unknownType.length - 1].replace("Type", ""));
         }
         
-        // Set the normalized type for the current {@link DefaultMetadataField}. If no normalized version can be found for the type, the type will default to
+        // Set the normalized type for the current {@link DefaultMetadataField}. If the type cannot be found in the normalizationMap, the type will default to
         // using a processed version of it's class name.
         private void setType() {
             int nullPos = currColumnQualifier.indexOf('\0');
             String type = currColumnQualifier.substring(nullPos + 1);
             String normalizedType = normalizationMap.get(type);
-            currField.addType(normalizedType != null ? normalizedType : determineUknownType(type));
+            currField.addType(normalizedType != null ? normalizedType : determineUnknownType(type));
         }
         
         // Set the last updated date for the current {@link DefaultMetadataField} based on the timestamp of the current entry.

--- a/service/src/test/java/datawave/microservice/metadata/DefaultMetadataFieldScannerTest.java
+++ b/service/src/test/java/datawave/microservice/metadata/DefaultMetadataFieldScannerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -109,12 +110,17 @@ public class DefaultMetadataFieldScannerTest {
         contributorId.setDescription(Collections.singleton(createDescription("ContributorId Description")));
         contributorId.setLastUpdated(DATE);
         
+        ArrayList<String> expectedTypes = new ArrayList<>();
+        expectedTypes.add("TestLcNoCookies*");
+        expectedTypes.add("TestNumberList*");
+        expectedTypes.add("Testleopard*");
+        
         DefaultMetadataField name = new DefaultMetadataField();
         name.setFieldName("NAME");
         name.setDataType("tvmaze");
         name.setForwardIndexed(true);
         name.setReverseIndexed(true);
-        name.setTypes(Collections.singletonList("Unknown"));
+        name.setTypes(expectedTypes);
         name.setLastUpdated(DATE);
         
         Collection<DefaultMetadataField> fields = scanner.getFields(Collections.emptyMap(), Collections.emptySet());
@@ -170,12 +176,17 @@ public class DefaultMetadataFieldScannerTest {
         contributorId.setDescription(Collections.singleton(createDescription("ContributorId Description")));
         contributorId.setLastUpdated(DATE);
         
+        ArrayList<String> expectedTypes = new ArrayList<>();
+        expectedTypes.add("TestLcNoCookies*");
+        expectedTypes.add("TestNumberList*");
+        expectedTypes.add("Testleopard*");
+        
         DefaultMetadataField name = new DefaultMetadataField();
         name.setFieldName("NAME");
         name.setDataType("tvmaze");
         name.setForwardIndexed(true);
         name.setReverseIndexed(true);
-        name.setTypes(Collections.singletonList("Unknown"));
+        name.setTypes(expectedTypes);
         name.setLastUpdated(DATE);
         
         Map<String,String> aliases = new HashMap<>();
@@ -205,7 +216,9 @@ public class DefaultMetadataFieldScannerTest {
         name.put(new Text(ColumnFamilyConstants.COLF_E), new Text("tvmaze"), TIMESTAMP, new Value());
         name.put(new Text(ColumnFamilyConstants.COLF_I), new Text("tvmaze"), TIMESTAMP, new Value());
         name.put(new Text(ColumnFamilyConstants.COLF_RI), new Text("tvmaze"), TIMESTAMP, new Value());
-        name.put(new Text(ColumnFamilyConstants.COLF_T), new Text("tvmaze\0not.a.known.type"), TIMESTAMP, new Value());
+        name.put(new Text(ColumnFamilyConstants.COLF_T), new Text("tvmaze\0datawave.data.type.testNumberListType"), TIMESTAMP, new Value());
+        name.put(new Text(ColumnFamilyConstants.COLF_T), new Text("tvmaze\0datawave.data.type.testLcNoCookiesType"), TIMESTAMP, new Value());
+        name.put(new Text(ColumnFamilyConstants.COLF_T), new Text("tvmaze\0datawave.data.type.testleopardType"), TIMESTAMP, new Value());
         
         BatchWriterConfig bwConfig = new BatchWriterConfig().setMaxMemory(10L).setMaxLatency(1, TimeUnit.SECONDS).setMaxWriteThreads(1);
         BatchWriter writer = connector.createBatchWriter(METADATA_TABLE, bwConfig);


### PR DESCRIPTION
This PR closes [DW-Issue-708](https://github.com/NationalSecurityAgency/datawave/issues/708)

Depends on [dw-type-utils PR 33](https://github.com/NationalSecurityAgency/datawave-type-utils/pull/33)

The data dictionary page previously showed "Unknown" for data types that were not in its list of datatypes. 

This PR adds:
- Use of a class defined data dictionary description for 'Types'
- Adds some new test cases