### PR TITLE
Add search functionality and other QOL changes to Edge Dictionary page

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -8,7 +8,7 @@
         <relativePath>../../../microservice-parent/pom.xml</relativePath>
     </parent>
     <artifactId>dictionary-api</artifactId>
-    <version>4.0.5-SNAPSHOT</version>
+    <version>4.0.5</version>
     <url>https://code.nsa.gov/datawave-dictionary-service</url>
     <scm>
         <connection>scm:git:https://github.com/NationalSecurityAgency/datawave-dictionary-service.git</connection>

--- a/api/src/main/java/datawave/webservice/dictionary/edge/DefaultEdgeDictionary.java
+++ b/api/src/main/java/datawave/webservice/dictionary/edge/DefaultEdgeDictionary.java
@@ -1,6 +1,7 @@
 package datawave.webservice.dictionary.edge;
 
 import java.io.IOException;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,7 +33,13 @@ public class DefaultEdgeDictionary extends EdgeDictionaryBase<DefaultEdgeDiction
                 implements TotalResultsAware, Message<DefaultEdgeDictionary>, HtmlProvider {
     
     private static final long serialVersionUID = 1L;
+    private final String jqueryUri;
+    private final String dataTablesUri;
     private static final String TITLE = "Edge Dictionary", SEP = ", ";
+    private static final String DATA_TABLES_TEMPLATE = "<script type=''text/javascript'' src=''{0}jquery.min.js''></script>\n"
+                    + "<script type=''text/javascript'' src=''{1}jquery.dataTables.min.js''></script>\n" + "<script type=''text/javascript''>\n"
+                    + "$(document).ready(function() '{' $(''#myTable'').dataTable('{'\"bPaginate\": false, \"aaSorting\": [[3, \"asc\"]], \"bStateSave\": true'}') '}')\n"
+                    + "</script>\n";
     
     @XmlElementWrapper(name = "EdgeMetadata")
     @XmlElement(name = "Metadata")
@@ -41,9 +48,12 @@ public class DefaultEdgeDictionary extends EdgeDictionaryBase<DefaultEdgeDiction
     @XmlElement(name = "TotalResults")
     private Long totalResults = null;
     
-    public DefaultEdgeDictionary() {}
+    public DefaultEdgeDictionary() {
+        this.jqueryUri = "/dictionary/webjars/jquery/";
+        this.dataTablesUri = "/dictionary/webjars/datatables/js/";
+    }
     
-    public DefaultEdgeDictionary(Collection<DefaultMetadata> fields) {
+    public DefaultEdgeDictionary(Collection<DefaultMetadata> fields, String jqueryUri, String dataTablesUri) {
         if (fields == null) {
             this.metadataList = null;
             setTotalResults(0);
@@ -52,6 +62,8 @@ public class DefaultEdgeDictionary extends EdgeDictionaryBase<DefaultEdgeDiction
             setTotalResults(this.metadataList.size());
             this.setHasResults(true);
         }
+        this.jqueryUri = jqueryUri;
+        this.dataTablesUri = dataTablesUri;
     }
     
     @Override
@@ -177,7 +189,7 @@ public class DefaultEdgeDictionary extends EdgeDictionaryBase<DefaultEdgeDiction
     
     @Override
     public String getHeadContent() {
-        return "";
+        return MessageFormat.format(DATA_TABLES_TEMPLATE, jqueryUri, dataTablesUri);
     }
     
     public String getPageHeader() {
@@ -187,28 +199,19 @@ public class DefaultEdgeDictionary extends EdgeDictionaryBase<DefaultEdgeDiction
     @Override
     public String getMainContent() {
         StringBuilder builder = new StringBuilder(2048);
-        builder.append("<div><ul>").append("<li class=\"left\">Edge Type: Defined either by Datawave Configuration files or Edge enrichment field.</li>")
-                        .append("<li class=\"left\">Edge Relationship: Defined by Datawave Configuration files</li>")
-                        .append("<li class=\"left\">Edge Attribute1 Source: Defined by Datawave Configuration files and optional attributes Attribute2 and Attribute3</li>")
-                        .append("<li class=\"left\">Fields: List of Field Name pairs used to generate this edge type.</li>")
-                        .append("<li class=\"left\">Fields Format:<pre>[Source Field, Target Field | Enrichment Field=Enrichment Field Value]</pre></li>")
-                        .append("<li class=\"left\">Date: start date of edge type creation, format: yyyyMMdd</li>").append("</ul></div>");
         
-        builder.append("<table id=\"myTable\" class=\"creds\">\n")
-                        .append("<thead><tr><th>Edge Type</th><th>Edge Relationship</th><th>Edge Attribute1 Source</th>")
-                        .append("<th>Fields</th><th>Date</th></tr></thead>");
+        builder.append("<div>\n");
+        builder.append("<div id=\"myTable_wrapper\" class=\"dataTables_wrapper no-footer\">\n");
+        builder.append("<table id=\"myTable\" class=\"dataTable no-footer\" role=\"grid\" aria-describedby=\"myTable_info\">\n")
+                        .append("<thead><tr><th title=\"Defined either by Datawave Configuration files or Edge enrichment field.\">Edge Type  &#9432;</th>")
+                        .append("<th title=\"Defined by Datawave Configuration files.\">Edge Relationship  &#9432;</th>")
+                        .append("<th title=\"Defined by Datawave Configuration files and optional attributes Attribute2 and Attribute3.\">Edge Attribute1 Source  &#9432;</th>")
+                        .append("<th title=\"List of Field Name pairs used to generate this edge type. Format: [Source Field, Target Field | Enrichment Field=Enrichment Field Value]\">Fields  &#9432;</th>")
+                        .append("<th title=\"Start date of edge type creation. Format: yyyyMMdd\">Date  &#9432;</th>").append("</tr></thead>");
         
         builder.append("<tbody>");
         int x = 0;
         for (MetadataBase<DefaultMetadata> metadata : this.getMetadataList()) {
-            // highlight alternating rows
-            if (x % 2 == 0) {
-                builder.append("<tr class=\"highlight\">");
-            } else {
-                builder.append("<tr>");
-            }
-            x++;
-            
             String type = metadata.getEdgeType();
             String relationship = metadata.getEdgeRelationship();
             String collect = metadata.getEdgeAttribute1Source();
@@ -231,6 +234,9 @@ public class DefaultEdgeDictionary extends EdgeDictionaryBase<DefaultEdgeDiction
         builder.append("</tbody>");
         
         builder.append("</table>\n");
+        builder.append("  <div class=\"dataTables_info\" id=\"myTable_info\" role=\"status\" aria-live=\"polite\"></div>\n");
+        builder.append("</div>\n");
+        builder.append("</div>");
         
         return builder.toString();
     }

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -26,7 +26,7 @@
         <start-class>datawave.microservice.dictionary.DictionaryService</start-class>
         <version.accumulo>2.1.1</version.accumulo>
         <version.curator>5.2.0</version.curator>
-        <version.datawave.dictionary-api>4.0.3</version.datawave.dictionary-api>
+        <version.datawave.dictionary-api>4.0.5</version.datawave.dictionary-api>
         <version.datawave.starter>4.0.2</version.datawave.starter>
         <version.datawave.starter-metadata>3.0.2</version.datawave.starter-metadata>
         <version.in-memory-accumulo>4.0.0</version.in-memory-accumulo>

--- a/service/src/main/java/datawave/microservice/dictionary/config/DictionaryServiceConfiguration.java
+++ b/service/src/main/java/datawave/microservice/dictionary/config/DictionaryServiceConfiguration.java
@@ -62,7 +62,7 @@ public class DictionaryServiceConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public EdgeDictionary datawaveEdgeDictionary(MetadataHelperFactory metadataHelperFactory) {
-        return new EdgeDictionaryImpl(metadataHelperFactory);
+        return new EdgeDictionaryImpl(metadataHelperFactory, "/dictionary/webjars/jquery/", "/dictionary/webjars/datatables/js/");
     }
     
     @Bean

--- a/service/src/main/java/datawave/microservice/dictionary/edge/EdgeDictionaryImpl.java
+++ b/service/src/main/java/datawave/microservice/dictionary/edge/EdgeDictionaryImpl.java
@@ -30,9 +30,13 @@ public class EdgeDictionaryImpl implements EdgeDictionary<DefaultEdgeDictionary,
     private static final Logger log = LoggerFactory.getLogger(EdgeDictionaryImpl.class);
     
     private final MetadataHelperFactory metadataHelperFactory;
+    private final String jqueryUri;
+    private final String dataTablesUri;
     
-    public EdgeDictionaryImpl(MetadataHelperFactory metadataHelperFactory) {
+    public EdgeDictionaryImpl(MetadataHelperFactory metadataHelperFactory, String jqueryUri, String dataTablesUri) {
         this.metadataHelperFactory = metadataHelperFactory;
+        this.jqueryUri = jqueryUri;
+        this.dataTablesUri = dataTablesUri;
     }
     
     @Override
@@ -117,6 +121,6 @@ public class EdgeDictionaryImpl implements EdgeDictionary<DefaultEdgeDictionary,
             meta.setEventFields(eFields);
             metadata.add(meta);
         }
-        return new DefaultEdgeDictionary(metadata);
+        return new DefaultEdgeDictionary(metadata, this.jqueryUri, this.dataTablesUri);
     }
 }


### PR DESCRIPTION
This PR adds the following to the Edge Dictionary page:

- Search functionality
- Column sorting
- Moved text on page to their respective columns
  - The same text appears when hovering over the column
  - Added an "info icon" to each column to indicate the ability to get additional info
  
Closes #35 