### PR TITLE
task/colInfo: Adding ToolTips to Columns for Data Dictionary

### DIFF
--- a/service/src/main/frontend/src/css/app.css
+++ b/service/src/main/frontend/src/css/app.css
@@ -40,6 +40,17 @@
   margin-top: 1em;
 }
 
+.tooltip-wrapper {
+  display: inline-block;
+  position: relative;
+}
+
+.tooltip-text {
+  font-size: 12px;
+  word-break: break-word;
+  text-align: center;
+}
+
 ::-webkit-scrollbar {
     height: 12px;
     width: 14px;
@@ -65,33 +76,33 @@
     background: #c1c1c1;
 }
 
+/* Sets a fixed height for the table container */
 .datawave-dictionary-sticky-sass {
-  /* height or max-height is important */
   height: 310px;
 }
 
+/* Applies a blur effect to the first row's headers for a frosted look */
 .datawave-dictionary-sticky-sass thead tr:first-child th {
-  /* bg color is important for th; just specify one */
   backdrop-filter: blur(2.5px);
 }
 
+/* Makes all table headers sticky to keep them visible while scrolling */
 .datawave-dictionary-sticky-sass thead tr th {
   position: sticky;
   z-index: 1;
 }
 
+/* Keeps the first row of headers stuck to the top of the table */
 .datawave-dictionary-sticky-sass thead tr:first-child th {
   top: 0;
 }
 
-/* this is when the loading indicator appears */
+/* Adjusts the position of the last row of headers when the table is in loading state */
 .datawave-dictionary-sticky-sass.q-table--loading thead tr:last-child th {
-  /* height of all previous header rows */
   top: 48px;
 }
 
-/* prevent scrolling behind sticky top row on focus */
+/* Ensures the body content scrolls without overlapping sticky headers */
 .datawave-dictionary-sticky-sass tbody {
-  /* height of all previous header rows */
   scroll-margin-top: 48px;
 }

--- a/service/src/main/frontend/src/functions/features.ts
+++ b/service/src/main/frontend/src/functions/features.ts
@@ -13,3 +13,21 @@ export async function copyLabel(colValue: any) {
     icon: 'bi-clipboard-fill'
   });
 }
+
+export function toolTipGen(colLabel: any): string {
+  const tooltips: Record<string, string> = {
+    'fieldName': 'Name of the field returned in the results. Can also be used as the field to query.',
+    'internalFieldName': 'The raw name as it is stored in the database. This field can be used in a query.',
+    'dataType': 'Used to partition the data for ingest and query. Not all fields are valid for all data types.',
+    'indexOnly': 'Field is only found in the Index Tables, not in the Shard Table. This field will not be returned in results and cannot be used in a filter function (#INCLUDE, #EXCLUDE, #ISNULL, #ISNOTNULL)',
+    'forwardIndexed': 'Value is in Forward Index (lexicographical ordered listing of values). Fields that are indexed can be queried as a stand alone term or anchor term in a query. Fields that are not indexed must be paired with an indexed field in the query.',
+    'reverseIndexed': 'Value is in the Reverse Index (lexicographical ordered listing of values stored in reverse "esrever" order). Fields that are reverse indexed can be queried with a leading wildcard as a stand alone term or anchor term in a query.',
+    'normalized': 'Indicates the value stored in the Shard Table is normalized.',
+    'Types': 'Indicates what type of normalization is applied.',
+    'tokenized': 'Indicates the value stored in the index/searched is tokenized.',
+    'Descriptions': 'Description of the data contained in the field.',
+    'lastUpdated': 'The last time data has been received for the field.'
+  };
+
+  return tooltips[colLabel] || colLabel;
+}

--- a/service/src/main/frontend/src/pages/DataDictionary.vue
+++ b/service/src/main/frontend/src/pages/DataDictionary.vue
@@ -86,16 +86,19 @@
                 @click="queryTable"
               />
         </template>
-
         <template v-slot:header="props">
           <q-tr :props="props">
             <q-th />
-            <q-th style="font-size: 13.7px;" v-for="col in props.cols" :key="col.name" :props="props">
-              {{ col.label }}
+            <q-th v-for="col in props.cols" :key="col.name" :props="props">
+              <div class="tooltip-wrapper">
+                {{ col.label }}
+                <q-tooltip class="tooltip-text" anchor="bottom middle" self="top middle" :offset="[0, 5]">
+                  {{ Feature.toolTipGen(col.name) }}
+                </q-tooltip>
+              </div>
             </q-th>
           </q-tr>
         </template>
-
         <template v-slot:body="props">
           <q-tr
             :props="props"
@@ -129,15 +132,17 @@
               :key="col.name"
               :props="props"
               style="font-size: 13px;"
-              :title="Formatters.parseVal(col.name, col.value)"
               @click="Feature.copyLabel(col.value)"
             >
               <label style="cursor: pointer;">
                 {{
-                Formatters.maxSubstring(
-                  Formatters.parseVal(col.name, col.value), col.name
-                )
-              }}
+                  Formatters.maxSubstring(
+                    Formatters.parseVal(col.name, col.value), col.name
+                  )
+                }}
+                <q-tooltip class="tooltip-text" anchor="bottom middle" self="top middle" :offset="[0, 5]">
+                  {{ Formatters.parseVal(col.name, col.value) }}
+                </q-tooltip>
               </label>
             </q-td>
           </q-tr>


### PR DESCRIPTION
This adds tooltips for the column headers on Data Dictionary. This ticket also:
- Cleans comments and makes them more clear.
- Fixes some styling issues.
- Fixes the tooltips for other row values in the table.